### PR TITLE
Reference Dockerfile without leading ./ to have proper preview rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For example:
  - uses: anchore/scan-action@master
        with:
          image-reference: "localbuild/testimage:latest"
-         dockerfile-path: "./Dockerfile"
+         dockerfile-path: "Dockerfile"
          fail-build: true
          include-app-packages: true
 ```
@@ -78,7 +78,7 @@ For example, to include a custom policy as: .anchore/policy.json in your code re
  - uses: anchore/scan-action@master
        with:
          image-reference: "localbuild/testimage:latest"
-         dockerfile-path: "./Dockerfile"
+         dockerfile-path: "Dockerfile"
          fail-build: true
          custom-policy-path: .anchore/policy.json
 ```
@@ -126,7 +126,7 @@ jobs:
     - uses: anchore/scan-action@master
       with:
         image-reference: "localbuild/testimage:latest"
-        dockerfile-path: "./Dockerfile"
+        dockerfile-path: "Dockerfile"
         fail-build: true
     - name: anchore inline scan JSON results
       run: for j in `ls ./anchore-reports/*.json`; do echo "---- ${j} ----"; cat ${j}; echo; done
@@ -147,7 +147,7 @@ jobs:
     - uses: anchore/scan-action@master
       with:
         image-reference: "localbuild/testimage:latest"
-        dockerfile-path: "./Dockerfile"
+        dockerfile-path: "Dockerfile"
         fail-build: true
         acs-report-enable: true
         #acs-report-severity-cutoff: "Medium"


### PR DESCRIPTION
I was following the examples in the README for my own repository and noticed that the preview for my Dockerfile did not render properly when I referred to it with a leasing "./"

![image](https://user-images.githubusercontent.com/1872314/84440550-7c32b500-ac3a-11ea-887e-5f4a04124aec.png)

In the moment I changed the `dockerfile-path` to "Dockerfile" the preview started to render properly:

![image](https://user-images.githubusercontent.com/1872314/84440629-a1272800-ac3a-11ea-80fb-086977538415.png)
