### PR TITLE
Update action workflow versions

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: ./
       with:
         image-reference: "alpine:latest"

--- a/.github/workflows/sarifdemo.yml
+++ b/.github/workflows/sarifdemo.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Run the local anchore scan action itself with sarif generation enabled
       uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - run: npm ci
     - run: npm audit --production
     - run: npm test -- --testPathIgnorePatterns action.test.js

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ even if vulnerabilities are found.
 In your workflow file, add a step:
 ```yaml
  - name: Scan image
-   uses: anchore/scan-action@master
+   uses: anchore/scan-action@1.0.6
    with:
      image-reference: "localbuild/testimage:latest"
 ```
@@ -38,7 +38,7 @@ That will make the job step fail of the policy evaluations detects a policy viol
 For example: 
 ```yaml
  - name: Scan image
-   uses: anchore/scan-action@master
+   uses: anchore/scan-action@1.0.6
    with:
      image-reference: "localbuild/testimage:latest"
      fail-build: true
@@ -59,7 +59,7 @@ holistic view of the container vulnerability set. To enable this feature, set th
 
 For example:
 ```yaml
- - uses: anchore/scan-action@master
+ - uses: anchore/scan-action@1.0.6
        with:
          image-reference: "localbuild/testimage:latest"
          dockerfile-path: "Dockerfile"
@@ -75,7 +75,7 @@ to the root of the workspace (which gets reset to the repository if you use the 
 
 For example, to include a custom policy as: .anchore/policy.json in your code repository, set:
 ```yaml
- - uses: anchore/scan-action@master
+ - uses: anchore/scan-action@1.0.6
        with:
          image-reference: "localbuild/testimage:latest"
          dockerfile-path: "Dockerfile"
@@ -144,7 +144,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag localbuild/testimage:latest
-    - uses: anchore/scan-action@master
+    - uses: anchore/scan-action@1.0.6
       with:
         image-reference: "localbuild/testimage:latest"
         dockerfile-path: "Dockerfile"


### PR DESCRIPTION
### Summary

This PR updates the workflows to use the latest `actions/checkout@v2` code and updates the README workflow examples to point to a specific tag.

### Details

This Pull Request introduces the following two changes:

- Following up on #34 by updating the `.github/workflows` on this repository to the latest `actions/checkout@v2` code
- Updates the `README` workflow examples to point to the latest tagged version of `anchore/scan-action@v1.0.6` instead of `master`.
  - GitHub [recommends](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsuses) you use a specific commit target in your workflows instead of `master` so you can ensure compatibility with your workflows, i.e. referencing `@master` means I always have the latest code instead of testing/verifying that latest change before implementing it in my workflows

### Further steps
I'd recommend the Anchore team implement a sliding version system for major versions in order to ease the adoption of code versions for end-users. This is detailed [in this documentation](https://help.github.com/en/actions/creating-actions/about-actions#using-tags-for-release-management), but the tl;dr is that Actions authors should attempt to use semantic versioning, and then a sliding major version number that always points to the latest tag for that major version.

- Example: `anchore/scan-action@v1` would point to the same sha as `anchore/scan-action@v1.0.6`