### PR TITLE
Fix handling of include-app-packages and debug input

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ For an overview of policy format and the checks it can perform, see the [Anchore
 | fail-build | Fail the build if policy evaluation returns a fail | | false |
 | include-app-packages | Include application packages for vulnerability matches. Requires more vuln data and thus scan will be slower but better results | | false |
 | custom-policy-path | A path to a policy json file for specifying a policy other than the default, which fails on >high vulnerabilities with fixes | | null |
-| anchore-version | An optional parameter to specify a specific version of anchore to use for the scan. Default is the version locked to the scan-action release | false | v0.7.1 |
+| anchore-version | An optional parameter to specify a specific version of anchore to use for the scan. Default is the version locked to the scan-action release | false | v0.7.3 |
 | acs-report-enable | Optionally, enable feature that causes a result.sarif report to be generated after successful action execution.  This report is compatible with GitHub Automated Code Scanning (ACS), as the artifact to upload for display as a Code Scanning Alert report. | | false |
 | acs-report-severity-cutoff | With ACS reporting enabled, optionally specify the minimum vulnerability severity to trigger an "error" level ACS result.  Valid choices are "Negligible", "Low", "Medium", "High" and "Critical".  Any vulnerability with a severity less than this value will lead to a "warning" result.  Default is "Medium". | | Medium |
 

--- a/action.yml
+++ b/action.yml
@@ -13,12 +13,15 @@ inputs:
   debug:
     description: 'Set this to any value to enable verbose debug output'
     required: false
+    default: 'false'
   fail-build:
     description: 'Set to any value to cause build to fail upon failed anchore policy evaluation'
     required: false
+    default: 'false'
   include-app-packages:
     description: 'Set to true to include software packages during vulnerability scanning - this option will increase runtime of the action significantly. By default only OS packages are scanned for vulnerabilities.'
     required: false
+    default: 'false'
   custom-policy-path:
     description: 'Path to a custom policy json file. See https://docs.anchore.com/current/docs/engine/general/concepts/policy/bundles/ for information on building bundles'
     required: false
@@ -28,9 +31,11 @@ inputs:
   acs-report-enable:
     description: 'Optionally, enable feature that causes a result.sarif report to be generated after successful action execution.  This report is compatible with GitHub Automated Code Scanning (ACS), as the artifact to upload for display as a Code Scanning Alert report.'
     required: false
+    default: 'false'
   acs-report-severity-cutoff:
     description: 'With ACS reporting enabled, optionally specify the minimum vulnerability severity to trigger an "error" level ACS result.  Valid choices are "Negligible", "Low", "Medium", "High" and "Critical".  Any vulnerability with a severity less than this value will lead to a "warning" result.  Default is "Medium".'
-    required: "Medium"
+    required: false
+    default: "Medium"
 outputs:
   billofmaterials:
     description: 'The json output report specifying the content of the image'

--- a/index.js
+++ b/index.js
@@ -231,7 +231,7 @@ async function run() {
         var inlineScanImage;
         const SEVERITY_LIST = ['Unknown', 'Negligible', 'Low', 'Medium', 'High', 'Critical'];
 
-        if (debug && debug.toLowerCase() === "true") {
+        if (debug.toLowerCase() === "true") {
             debug = "true";
         } else {
             debug = "false";
@@ -263,7 +263,7 @@ async function run() {
             version = `${defaultAnchoreVersion}`;
         }
 
-        if (includePackages && includePackages.toLowerCase() === "true") {
+        if (includePackages.toLowerCase() === "true") {
             includePackages = true;
             inlineScanImage = `docker.io/anchore/inline-scan:v${version}`;
         } else {

--- a/index.js
+++ b/index.js
@@ -231,10 +231,10 @@ async function run() {
         var inlineScanImage;
         const SEVERITY_LIST = ['Unknown', 'Negligible', 'Low', 'Medium', 'High', 'Critical'];
 
-        if (!debug) {
-            debug = "false";
-        } else {
+        if (debug && debug.toLowerCase() === "true") {
             debug = "true";
+        } else {
+            debug = "false";
         }
 
         if (failBuild.toLowerCase() === "true") {
@@ -249,10 +249,7 @@ async function run() {
             acsReportEnable = false;
         }
 
-        if (!acsSevCutoff) {
-            acsSevCutoff = "Medium"
-        }
-        else if (
+        if (
             !SEVERITY_LIST.some(
               item =>
                 typeof acsSevCutoff === 'string' &&
@@ -260,18 +257,18 @@ async function run() {
             )
           ) {
             throw new Error ('Invalid acs-report-severity-cutoff value is set - please ensure you are choosing either Unknown, Negligible, Low, Medium, High, or Critical');
-          }
+        }
 
         if (!version) {
             version = `${defaultAnchoreVersion}`;
         }
 
-        if (!includePackages) {
-            includePackages = false;
-            inlineScanImage = `docker.io/anchore/inline-scan-slim:v${version}`;
-        } else {
+        if (includePackages && includePackages.toLowerCase() === "true") {
             includePackages = true;
             inlineScanImage = `docker.io/anchore/inline-scan:v${version}`;
+        } else {
+            includePackages = false;
+            inlineScanImage = `docker.io/anchore/inline-scan-slim:v${version}`;
         }
 
         if (customPolicyPath) {


### PR DESCRIPTION
The inputs include-app-packages and debug were not handled correctly. If include-app-packages was set to false, then the slim image version wasn't used.

I also set the default values in the action.yml, because for me it was somehow confusing that there are defaults mentioned in the README, but they were not explicit defined in most cases.