### PR TITLE
Fix overzealous rule deduplication in SARIF output.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -222,14 +222,15 @@ function vulnerabilities_to_sarif(input_vulnerabilities, severity_cutoff_param, 
 function grype_render_rules(vulnerabilities) {
     var ret = {}
     if (vulnerabilities) {
-    let vulnIDs = [];
+    let ruleIDs = [];
     // This uses .reduce() because there can be duplicate vulnerabilities which the SARIF schema complains about.
     ret = vulnerabilities.reduce(function(result, v) {
-        if (!vulnIDs.includes(v.vulnerability.id)) {
-          vulnIDs.push(v.vulnerability.id);
+        let ruleID = "ANCHOREVULN_"+v.vulnerability.id+"_"+v.artifact.type+"_"+v.artifact.name+"_"+v.artifact.version;
+        if (!ruleIDs.includes(ruleID)) {
+          ruleIDs.push(ruleID);
           result.push(
             {
-                "id": "ANCHOREVULN_"+v.vulnerability.id+"_"+v.artifact.type+"_"+v.artifact.name+"_"+v.artifact.version,
+                "id": ruleID,
                 "shortDescription": {
                     "text": v.vulnerability.id + " Severity=" + v.vulnerability.severity + " Package=" + v.artifact.name + " Version=" + v.artifact.version
                 },

--- a/index.js
+++ b/index.js
@@ -215,14 +215,15 @@ function vulnerabilities_to_sarif(input_vulnerabilities, severity_cutoff_param, 
 function grype_render_rules(vulnerabilities) {
     var ret = {}
     if (vulnerabilities) {
-    let vulnIDs = [];
+    let ruleIDs = [];
     // This uses .reduce() because there can be duplicate vulnerabilities which the SARIF schema complains about.
     ret = vulnerabilities.reduce(function(result, v) {
-        if (!vulnIDs.includes(v.vulnerability.id)) {
-          vulnIDs.push(v.vulnerability.id);
+        let ruleID = "ANCHOREVULN_"+v.vulnerability.id+"_"+v.artifact.type+"_"+v.artifact.name+"_"+v.artifact.version;
+        if (!ruleIDs.includes(ruleID)) {
+          ruleIDs.push(ruleID);
           result.push(
             {
-                "id": "ANCHOREVULN_"+v.vulnerability.id+"_"+v.artifact.type+"_"+v.artifact.name+"_"+v.artifact.version,
+                "id": ruleID,
                 "shortDescription": {
                     "text": v.vulnerability.id + " Severity=" + v.vulnerability.severity + " Package=" + v.artifact.name + " Version=" + v.artifact.version
                 },


### PR DESCRIPTION
Currently in the SARIF output of the Action it's possible to have results included who's `ruleId` does not match any rule in the list of rules. This is because rules are de-duplcated on the vulnerability ID, but the rule ID also includes information about the artifact. This means only one rule gets created for all these IDs:

> ANCHOREVULN_CVE-2004-0971_deb_krb5-multidev_1.12.1+dfsg-19+deb8u4
> ANCHOREVULN_CVE-2004-0971_deb_libgssapi-krb5-2_1.12.1+dfsg-19+deb8u4
> ANCHOREVULN_CVE-2004-0971_deb_libgssrpc4_1.12.1+dfsg-19+deb8u4
> ANCHOREVULN_CVE-2004-0971_deb_libk5crypto3_1.12.1+dfsg-19+deb8u4
> ANCHOREVULN_CVE-2004-0971_deb_libkadm5clnt-mit9_1.12.1+dfsg-19+deb8u4
> ANCHOREVULN_CVE-2004-0971_deb_libkadm5srv-mit9_1.12.1+dfsg-19+deb8u4
> ANCHOREVULN_CVE-2004-0971_deb_libkdb5-7_1.12.1+dfsg-19+deb8u4
> ANCHOREVULN_CVE-2004-0971_deb_libkrb5-3_1.12.1+dfsg-19+deb8u4

To fix this, I've modified the deduplcation logic to deduplicate on rule ID rather than on vulnerability ID.