### PR TITLE
fix undefined items message when scanning containers

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const grypeVersion = '0.1.0'
 
 // sarif code
 function convert_severity_to_acs_level(input_severity, severity_cutoff_param) {
-  // The `severity_cutoff_param` has been lowercased for case-insensitivity at this point, but the 
+  // The `severity_cutoff_param` has been lowercased for case-insensitivity at this point, but the
   // severity from the vulnerability will be capitalized, so this must be capitalized again to calculate
   // using the same object
   let param = severity_cutoff_param[0].toUpperCase() + severity_cutoff_param.substring(1)
@@ -92,7 +92,7 @@ function textMessage(v) {
   } else {
     prefix = "The container image contains software with a vulnerability: ";
   }
-  return prefix + "(" + v.package + " type=" + v.package_type + ")";
+  return prefix + "(" + v.artifact.name + " type=" + v.artifact.type + ")";
 }
 
 
@@ -248,7 +248,7 @@ function grype_render_rules(vulnerabilities) {
                 }
               }
           );
-          
+
         }
         return result;
       }, []);


### PR DESCRIPTION
Example output with the fix:

```
|           "ruleId": "ANCHOREVULN_CVE-2016-2779_deb_libsmartcols1_2.25.2-6",
|           "ruleIndex": 0,
|           "level": "error",
|           "message": {
|             "text": "The container image contains software with a vulnerability: (libsmartcols1 type=deb)",
|             "id": "default"
|           },
```

Not sure why the compiled `index.js` now has a ton of changes :/