### PR TITLE
bump grype to 0.6.1

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11,7 +11,7 @@ const { exec } = __webpack_require__(514);
 const fs = __webpack_require__(747);
 
 const grypeBinary = 'grype'
-const grypeVersion = '0.5.0'
+const grypeVersion = '0.6.1'
 
 // sarif code
 function convert_severity_to_acs_level(input_severity, severity_cutoff_param) {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const { exec } = require('@actions/exec');
 const fs = require('fs');
 
 const grypeBinary = 'grype'
-const grypeVersion = '0.5.0'
+const grypeVersion = '0.6.1'
 
 // sarif code
 function convert_severity_to_acs_level(input_severity, severity_cutoff_param) {


### PR DESCRIPTION
Bumping to the latest grype (`0.6.1`) pulls in a version of syft that addresses issue #78 

Fixes #78 