### PR TITLE
Improve SARIF reporting

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -254,7 +254,7 @@ function vulnerabilities_to_sarif(input_vulnerabilities, severity_cutoff_param, 
             "kind": "namespace"
                     }
         ],
-        "results": grype_render_results(vulnerabilities, severity_cutoff_param),
+        "results": grype_render_results(vulnerabilities, severity_cutoff_param, source),
         "columnKind": "utf16CodeUnits"
             }
     ]

--- a/dist/index.js
+++ b/dist/index.js
@@ -237,11 +237,15 @@ function grype_render_rules(vulnerabilities) {
           result.push(
             {
                 "id": ruleID,
+                // Title of the SARIF report
                 "shortDescription": {
-                    "text": v.vulnerability.id + " Severity=" + v.vulnerability.severity + " Package=" + v.artifact.name + " Version=" + v.artifact.version
+                  "text": `${v.vulnerability.id} ${v.vulnerability.severity} vulnerability for ${v.artifact.name} package`
+                    //"text": v.vulnerability.id + " Severity=" + v.vulnerability.severity + " Package=" + v.artifact.name + " Version=" + v.artifact.version
                 },
+                // Subtitle of the SARIF report
                 "fullDescription": {
-                    "text": v.vulnerability.id + " Severity=" + v.vulnerability.severity + " Package=" + v.artifact.name + " Version=" + v.artifact.version
+                    //"text": v.vulnerability.id + " Severity=" + v.vulnerability.severity + " Package=" + v.artifact.name + " Version=" + v.artifact.version
+                  "text": `${v.vulnerability.description}`
                 },
                 "help": {
                     "text": "Vulnerability "+v.vulnerability.id+"\n"+

--- a/dist/index.js
+++ b/dist/index.js
@@ -219,6 +219,20 @@ function vulnerabilities_to_sarif(input_vulnerabilities, severity_cutoff_param, 
 }
 
 
+function make_subtitle(v) {
+  let subtitle = `${v.vulnerability.description}`
+  if (subtitle != "undefined") {
+    return subtitle
+  }
+
+  if (v.vulnerability.fixedInVersion) {
+    return `Version ${v.artifact.version} is affected with an available fix in version ${v.vulnerability.fixedInVersion}`
+  }
+
+  return `Version ${v.artifact.version} is affected with no fixes reported yet.` 
+}
+
+
 function grype_render_rules(vulnerabilities) {
     var ret = {}
     if (vulnerabilities) {
@@ -245,7 +259,7 @@ function grype_render_rules(vulnerabilities) {
                 // Subtitle of the SARIF report
                 "fullDescription": {
                     //"text": v.vulnerability.id + " Severity=" + v.vulnerability.severity + " Package=" + v.artifact.name + " Version=" + v.artifact.version
-                  "text": `${v.vulnerability.description}`
+                  "text": make_subtitle(v)
                 },
                 "help": {
                     "text": "Vulnerability "+v.vulnerability.id+"\n"+

--- a/dist/index.js
+++ b/dist/index.js
@@ -91,59 +91,6 @@ function dottedQuadFileVersion(version) {
 }
 
 
-function render_results(vulnerabilities, severity_cutoff_param) {
-  var ret = {};
-
-  if (vulnerabilities) {
-    ret = vulnerabilities.map((v) => {
-      return {
-        ruleId:
-          "ANCHOREVULN_" + v.vuln + "_" + v.package_type + "_" + v.package,
-        ruleIndex: 0,
-        level: convert_severity_to_acs_level(v.severity, severity_cutoff_param),
-        message: {
-          text: textMessage(v),
-          id: "default",
-        },
-        analysisTarget: {
-          uri: getLocation(v),
-          index: 0,
-        },
-        locations: [
-          {
-            physicalLocation: {
-              artifactLocation: {
-                uri: getLocation(v),
-              },
-              region: {
-                startLine: 1,
-                startColumn: 1,
-                endLine: 1,
-                endColumn: 1,
-                byteOffset: 1,
-                byteLength: 1,
-              },
-            },
-            logicalLocations: [
-              {
-                fullyQualifiedName: "dockerfile",
-              },
-            ],
-          },
-        ],
-        suppressions: [
-          {
-            kind: "external",
-          },
-        ],
-        baselineState: "unchanged",
-      };
-    });
-  }
-  return ret;
-}
-
-
 function make_subtitle(v) {
   let subtitle = `${v.vulnerability.description}`
   if (subtitle != "undefined") {
@@ -158,13 +105,19 @@ function make_subtitle(v) {
 }
 
 
-function grype_render_rules(vulnerabilities) {
+function grype_render_rules(vulnerabilities, source) {
     var ret = {}
+    let scheme = sourceScheme();
     if (vulnerabilities) {
     let ruleIDs = [];
     // This uses .reduce() because there can be duplicate vulnerabilities which the SARIF schema complains about.
     ret = vulnerabilities.reduce(function(result, v) {
-        let ruleID = "ANCHOREVULN_"+v.vulnerability.id+"_"+v.artifact.type+"_"+v.artifact.name+"_"+v.artifact.version;
+        let ruleID = `ANCHOREVULN_${v.vulnerability.id}_${v.artifact.type}_${v.artifact.name}_${v.artifact.version}`
+        if (scheme == "docker") {
+          // include the container as part of the rule id so that users can sort by that
+            ruleID = `ANCHOREVULN_${source}_${v.vulnerability.id}_${v.artifact.type}_${v.artifact.name}_${v.artifact.version}`
+        }
+
         if (!ruleIDs.includes(ruleID)) {
           ruleIDs.push(ruleID);
           // Entirely possible to not have any links whatsoever
@@ -210,20 +163,18 @@ function grype_render_rules(vulnerabilities) {
     return(ret);
 }
 
-function grype_render_results(vulnerabilities, severity_cutoff_param) {
+function grype_render_results(vulnerabilities, severity_cutoff_param, source) {
   var ret = {};
+  let scheme = sourceScheme();
   if (vulnerabilities) {
     ret = vulnerabilities.map((v) => {
+      let ruleid = `ANCHOREVULN_${v.vulnerability.id}_${v.artifact.type}_${v.artifact.name}_${v.artifact.version}`
+      if (scheme == "docker") {
+        // include the container as part of the rule id so that users can sort by that
+          ruleid = `ANCHOREVULN_${source}_${v.vulnerability.id}_${v.artifact.type}_${v.artifact.name}_${v.artifact.version}`
+      }
       return {
-        ruleId:
-          "ANCHOREVULN_" +
-          v.vulnerability.id +
-          "_" +
-          v.artifact.type +
-          "_" +
-          v.artifact.name +
-          "_" +
-          v.artifact.version,
+        ruleId: ruleid,
         ruleIndex: 0,
         level: convert_severity_to_acs_level(
           v.vulnerability.severity,
@@ -276,7 +227,7 @@ function grype_render_results(vulnerabilities, severity_cutoff_param) {
 }
 
 
-function vulnerabilities_to_sarif(input_vulnerabilities, severity_cutoff_param, version) {
+function vulnerabilities_to_sarif(input_vulnerabilities, severity_cutoff_param, version, source) {
     let rawdata = fs.readFileSync(input_vulnerabilities);
     let parsed = JSON.parse(rawdata);
     let vulnerabilities = parsed.matches;
@@ -293,7 +244,7 @@ function vulnerabilities_to_sarif(input_vulnerabilities, severity_cutoff_param, 
             "version": version,
             "semanticVersion": version,
             "dottedQuadFileVersion": dottedQuadFileVersion(version),
-            "rules": grype_render_rules(vulnerabilities)
+            "rules": grype_render_rules(vulnerabilities, source)
             }
         },
         "logicalLocations": [
@@ -500,7 +451,7 @@ async function run() {
 
       if (acsReportEnable) {
         try {
-          sarifGrypeGeneration(severityCutoff.toLowerCase(), version);
+          sarifGrypeGeneration(severityCutoff.toLowerCase(), version, source);
         } catch (err) {
           throw new Error(err);
         }
@@ -534,10 +485,10 @@ async function run() {
     }
 }
 
-function sarifGrypeGeneration(severity_cutoff_param, version){
+function sarifGrypeGeneration(severity_cutoff_param, version, source){
     // sarif generate section
     const SARIF_FILE = "./results.sarif";
-    let sarifOutput = vulnerabilities_to_sarif("./vulnerabilities.json", severity_cutoff_param, version);
+    let sarifOutput = vulnerabilities_to_sarif("./vulnerabilities.json", severity_cutoff_param, version, source);
     fs.writeFileSync(SARIF_FILE, JSON.stringify(sarifOutput, null, 2));
     core.setOutput('sarif', SARIF_FILE);
     // end sarif generate section

--- a/dist/index.js
+++ b/dist/index.js
@@ -89,17 +89,15 @@ function getLocation(v) {
 }
 
 function textMessage(v) {
+  let path = getLocation(v);
   var scheme = sourceScheme();
-  var prefix;
+  let prefix = `The path ${path} reports ${v.artifact.name} at version ${v.package_version} `;
+
   if (["dir", "tar"].includes(scheme)) {
-    prefix =
-      "The path " +
-      getLocation(v) +
-      " would result in an installed vulnerability: ";
+    return prefix + ` which would result in a vulnerable (${v.artifact.type}) package installed`;
   } else {
-    prefix = "The container image contains software with a vulnerability: ";
+    return prefix + `which is a vulnerable (${v.artifact.type}) package installed in the container`;
   }
-  return prefix + "(" + v.artifact.name + " type=" + v.artifact.type + ")";
 }
 
 
@@ -254,11 +252,9 @@ function grype_render_rules(vulnerabilities) {
                 // Title of the SARIF report
                 "shortDescription": {
                   "text": `${v.vulnerability.id} ${v.vulnerability.severity} vulnerability for ${v.artifact.name} package`
-                    //"text": v.vulnerability.id + " Severity=" + v.vulnerability.severity + " Package=" + v.artifact.name + " Version=" + v.artifact.version
                 },
                 // Subtitle of the SARIF report
                 "fullDescription": {
-                    //"text": v.vulnerability.id + " Severity=" + v.vulnerability.severity + " Package=" + v.artifact.name + " Version=" + v.artifact.version
                   "text": make_subtitle(v)
                 },
                 "help": {

--- a/dist/index.js
+++ b/dist/index.js
@@ -53,14 +53,14 @@ function getLocation(v) {
 }
 
 function textMessage(v) {
-  let path = getLocation(v);
+  const path = getLocation(v);
   var scheme = sourceScheme();
   let prefix = `The path ${path} reports ${v.artifact.name} at version ${v.artifact.version} `;
 
   if (["dir", "tar"].includes(scheme)) {
-    return prefix + ` which would result in a vulnerable (${v.artifact.type}) package installed`;
+    return `${prefix} which would result in a vulnerable (${v.artifact.type}) package installed`;
   } else {
-    return prefix + `which is a vulnerable (${v.artifact.type}) package installed in the container`;
+    return `${prefix} which is a vulnerable (${v.artifact.type}) package installed in the container`;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -46,14 +46,14 @@ function getLocation(v) {
 }
 
 function textMessage(v) {
-  let path = getLocation(v);
+  const path = getLocation(v);
   var scheme = sourceScheme();
   let prefix = `The path ${path} reports ${v.artifact.name} at version ${v.artifact.version} `;
 
   if (["dir", "tar"].includes(scheme)) {
-    return prefix + ` which would result in a vulnerable (${v.artifact.type}) package installed`;
+    return `${prefix} which would result in a vulnerable (${v.artifact.type}) package installed`;
   } else {
-    return prefix + `which is a vulnerable (${v.artifact.type}) package installed in the container`;
+    return `${prefix} which is a vulnerable (${v.artifact.type}) package installed in the container`;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -247,7 +247,7 @@ function vulnerabilities_to_sarif(input_vulnerabilities, severity_cutoff_param, 
             "kind": "namespace"
                     }
         ],
-        "results": grype_render_results(vulnerabilities, severity_cutoff_param),
+        "results": grype_render_results(vulnerabilities, severity_cutoff_param, source),
         "columnKind": "utf16CodeUnits"
             }
     ]

--- a/index.js
+++ b/index.js
@@ -212,6 +212,20 @@ function vulnerabilities_to_sarif(input_vulnerabilities, severity_cutoff_param, 
 }
 
 
+function make_subtitle(v) {
+  let subtitle = `${v.vulnerability.description}`
+  if (subtitle != "undefined") {
+    return subtitle
+  }
+
+  if (v.vulnerability.fixedInVersion) {
+    return `Version ${v.artifact.version} is affected with an available fix in version ${v.vulnerability.fixedInVersion}`
+  }
+
+  return `Version ${v.artifact.version} is affected with no fixes reported yet.` 
+}
+
+
 function grype_render_rules(vulnerabilities) {
     var ret = {}
     if (vulnerabilities) {
@@ -238,7 +252,7 @@ function grype_render_rules(vulnerabilities) {
                 // Subtitle of the SARIF report
                 "fullDescription": {
                     //"text": v.vulnerability.id + " Severity=" + v.vulnerability.severity + " Package=" + v.artifact.name + " Version=" + v.artifact.version
-                  "text": `${v.vulnerability.description}`
+                  "text": make_subtitle(v)
                 },
                 "help": {
                     "text": "Vulnerability "+v.vulnerability.id+"\n"+

--- a/index.js
+++ b/index.js
@@ -82,17 +82,15 @@ function getLocation(v) {
 }
 
 function textMessage(v) {
+  let path = getLocation(v);
   var scheme = sourceScheme();
-  var prefix;
+  let prefix = `The path ${path} reports ${v.artifact.name} at version ${v.package_version} `;
+
   if (["dir", "tar"].includes(scheme)) {
-    prefix =
-      "The path " +
-      getLocation(v) +
-      " would result in an installed vulnerability: ";
+    return prefix + ` which would result in a vulnerable (${v.artifact.type}) package installed`;
   } else {
-    prefix = "The container image contains software with a vulnerability: ";
+    return prefix + `which is a vulnerable (${v.artifact.type}) package installed in the container`;
   }
-  return prefix + "(" + v.artifact.name + " type=" + v.artifact.type + ")";
 }
 
 
@@ -247,11 +245,9 @@ function grype_render_rules(vulnerabilities) {
                 // Title of the SARIF report
                 "shortDescription": {
                   "text": `${v.vulnerability.id} ${v.vulnerability.severity} vulnerability for ${v.artifact.name} package`
-                    //"text": v.vulnerability.id + " Severity=" + v.vulnerability.severity + " Package=" + v.artifact.name + " Version=" + v.artifact.version
                 },
                 // Subtitle of the SARIF report
                 "fullDescription": {
-                    //"text": v.vulnerability.id + " Severity=" + v.vulnerability.severity + " Package=" + v.artifact.name + " Version=" + v.artifact.version
                   "text": make_subtitle(v)
                 },
                 "help": {

--- a/index.js
+++ b/index.js
@@ -84,59 +84,6 @@ function dottedQuadFileVersion(version) {
 }
 
 
-function render_results(vulnerabilities, severity_cutoff_param) {
-  var ret = {};
-
-  if (vulnerabilities) {
-    ret = vulnerabilities.map((v) => {
-      return {
-        ruleId:
-          "ANCHOREVULN_" + v.vuln + "_" + v.package_type + "_" + v.package,
-        ruleIndex: 0,
-        level: convert_severity_to_acs_level(v.severity, severity_cutoff_param),
-        message: {
-          text: textMessage(v),
-          id: "default",
-        },
-        analysisTarget: {
-          uri: getLocation(v),
-          index: 0,
-        },
-        locations: [
-          {
-            physicalLocation: {
-              artifactLocation: {
-                uri: getLocation(v),
-              },
-              region: {
-                startLine: 1,
-                startColumn: 1,
-                endLine: 1,
-                endColumn: 1,
-                byteOffset: 1,
-                byteLength: 1,
-              },
-            },
-            logicalLocations: [
-              {
-                fullyQualifiedName: "dockerfile",
-              },
-            ],
-          },
-        ],
-        suppressions: [
-          {
-            kind: "external",
-          },
-        ],
-        baselineState: "unchanged",
-      };
-    });
-  }
-  return ret;
-}
-
-
 function make_subtitle(v) {
   let subtitle = `${v.vulnerability.description}`
   if (subtitle != "undefined") {
@@ -151,13 +98,19 @@ function make_subtitle(v) {
 }
 
 
-function grype_render_rules(vulnerabilities) {
+function grype_render_rules(vulnerabilities, source) {
     var ret = {}
+    let scheme = sourceScheme();
     if (vulnerabilities) {
     let ruleIDs = [];
     // This uses .reduce() because there can be duplicate vulnerabilities which the SARIF schema complains about.
     ret = vulnerabilities.reduce(function(result, v) {
-        let ruleID = "ANCHOREVULN_"+v.vulnerability.id+"_"+v.artifact.type+"_"+v.artifact.name+"_"+v.artifact.version;
+        let ruleID = `ANCHOREVULN_${v.vulnerability.id}_${v.artifact.type}_${v.artifact.name}_${v.artifact.version}`
+        if (scheme == "docker") {
+          // include the container as part of the rule id so that users can sort by that
+            ruleID = `ANCHOREVULN_${source}_${v.vulnerability.id}_${v.artifact.type}_${v.artifact.name}_${v.artifact.version}`
+        }
+
         if (!ruleIDs.includes(ruleID)) {
           ruleIDs.push(ruleID);
           // Entirely possible to not have any links whatsoever
@@ -203,20 +156,18 @@ function grype_render_rules(vulnerabilities) {
     return(ret);
 }
 
-function grype_render_results(vulnerabilities, severity_cutoff_param) {
+function grype_render_results(vulnerabilities, severity_cutoff_param, source) {
   var ret = {};
+  let scheme = sourceScheme();
   if (vulnerabilities) {
     ret = vulnerabilities.map((v) => {
+      let ruleid = `ANCHOREVULN_${v.vulnerability.id}_${v.artifact.type}_${v.artifact.name}_${v.artifact.version}`
+      if (scheme == "docker") {
+        // include the container as part of the rule id so that users can sort by that
+          ruleid = `ANCHOREVULN_${source}_${v.vulnerability.id}_${v.artifact.type}_${v.artifact.name}_${v.artifact.version}`
+      }
       return {
-        ruleId:
-          "ANCHOREVULN_" +
-          v.vulnerability.id +
-          "_" +
-          v.artifact.type +
-          "_" +
-          v.artifact.name +
-          "_" +
-          v.artifact.version,
+        ruleId: ruleid,
         ruleIndex: 0,
         level: convert_severity_to_acs_level(
           v.vulnerability.severity,
@@ -269,7 +220,7 @@ function grype_render_results(vulnerabilities, severity_cutoff_param) {
 }
 
 
-function vulnerabilities_to_sarif(input_vulnerabilities, severity_cutoff_param, version) {
+function vulnerabilities_to_sarif(input_vulnerabilities, severity_cutoff_param, version, source) {
     let rawdata = fs.readFileSync(input_vulnerabilities);
     let parsed = JSON.parse(rawdata);
     let vulnerabilities = parsed.matches;
@@ -286,7 +237,7 @@ function vulnerabilities_to_sarif(input_vulnerabilities, severity_cutoff_param, 
             "version": version,
             "semanticVersion": version,
             "dottedQuadFileVersion": dottedQuadFileVersion(version),
-            "rules": grype_render_rules(vulnerabilities)
+            "rules": grype_render_rules(vulnerabilities, source)
             }
         },
         "logicalLocations": [
@@ -493,7 +444,7 @@ async function run() {
 
       if (acsReportEnable) {
         try {
-          sarifGrypeGeneration(severityCutoff.toLowerCase(), version);
+          sarifGrypeGeneration(severityCutoff.toLowerCase(), version, source);
         } catch (err) {
           throw new Error(err);
         }
@@ -527,10 +478,10 @@ async function run() {
     }
 }
 
-function sarifGrypeGeneration(severity_cutoff_param, version){
+function sarifGrypeGeneration(severity_cutoff_param, version, source){
     // sarif generate section
     const SARIF_FILE = "./results.sarif";
-    let sarifOutput = vulnerabilities_to_sarif("./vulnerabilities.json", severity_cutoff_param, version);
+    let sarifOutput = vulnerabilities_to_sarif("./vulnerabilities.json", severity_cutoff_param, version, source);
     fs.writeFileSync(SARIF_FILE, JSON.stringify(sarifOutput, null, 2));
     core.setOutput('sarif', SARIF_FILE);
     // end sarif generate section

--- a/index.js
+++ b/index.js
@@ -29,42 +29,6 @@ function convert_severity_to_acs_level(input_severity, severity_cutoff_param) {
   return ret;
 }
 
-function render_rules(vulnerabilities) {
-    var ret = {}
-    if (vulnerabilities) {
-    ret = vulnerabilities.map(v =>
-                  {
-                      return {
-                      "id": "ANCHOREVULN_"+v.vuln+"_"+v.package_type+"_"+v.package,
-                      "shortDescription": {
-                          "text": v.vuln + " Severity=" + v.severity + " Package=" + v.package
-                      },
-                      "fullDescription": {
-                          "text": v.vuln + " Severity=" + v.severity + " Package=" + v.package
-                      },
-                      "help": {
-                          "text": "Vulnerability "+v.vuln+"\n"+
-                          "Severity: "+v.severity+"\n"+
-                          "Package: "+v.package_name+"\n"+
-                          "Version: "+v.package_version+"\n"+
-                          "Fix Version: "+v.fix+"\n"+
-                          "Type: "+v.package_type+"\n"+
-                          "Location: "+v.package_path+"\n"+
-                          "Data Namespace: "+v.feed + ", "+v.feed_group+"\n"+
-                          "Link: ["+v.vuln+"]("+v.url+")",
-                          "markdown": "**Vulnerability "+v.vuln+"**\n"+
-                          "| Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |\n"+
-                          "| --- | --- | --- | --- | --- | --- | --- | --- |\n"+
-                          "|"+v.severity+"|"+v.package_name+"|"+v.package_version+"|"+v.fix+"|"+v.package_type+"|"+v.package_path+"|"+v.feed_group+"|["+v.vuln+"]("+v.url+")|\n"
-                      }
-
-                      }
-                  }
-                 );
-    }
-    return(ret);
-}
-
 function getLocation(v) {
   if (v.artifact.locations.length) {
     // If the scan was against a directory, the location will be a string
@@ -84,7 +48,7 @@ function getLocation(v) {
 function textMessage(v) {
   let path = getLocation(v);
   var scheme = sourceScheme();
-  let prefix = `The path ${path} reports ${v.artifact.name} at version ${v.package_version} `;
+  let prefix = `The path ${path} reports ${v.artifact.name} at version ${v.artifact.version} `;
 
   if (["dir", "tar"].includes(scheme)) {
     return prefix + ` which would result in a vulnerable (${v.artifact.type}) package installed`;
@@ -173,43 +137,6 @@ function render_results(vulnerabilities, severity_cutoff_param) {
 }
 
 
-function vulnerabilities_to_sarif(input_vulnerabilities, severity_cutoff_param, version) {
-    let rawdata = fs.readFileSync(input_vulnerabilities);
-    let vulnerabilities_raw = JSON.parse(rawdata);
-    let vulnerabilities = vulnerabilities_raw.vulnerabilities;
-
-    const sarifOutput = {
-    "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
-    "version": "2.1.0",
-    "runs": [
-            {
-        "tool": {
-            "driver": {
-            "name": "Anchore Container Vulnerability Report",
-            "fullName": "Anchore Container Vulnerability Report",
-            "version": version,
-            "semanticVersion": version,
-            "dottedQuadFileVersion": dottedQuadFileVersion(version),
-            "rules": render_rules(vulnerabilities)
-            }
-        },
-        "logicalLocations": [
-                    {
-            "name": "dockerfile",
-            "fullyQualifiedName": "dockerfile",
-            "kind": "namespace"
-                    }
-        ],
-        "results": render_results(vulnerabilities, severity_cutoff_param),
-        "columnKind": "utf16CodeUnits"
-            }
-    ]
-    }
-
-    return(sarifOutput)
-}
-
-
 function make_subtitle(v) {
   let subtitle = `${v.vulnerability.description}`
   if (subtitle != "undefined") {
@@ -220,7 +147,7 @@ function make_subtitle(v) {
     return `Version ${v.artifact.version} is affected with an available fix in version ${v.vulnerability.fixedInVersion}`
   }
 
-  return `Version ${v.artifact.version} is affected with no fixes reported yet.` 
+  return `Version ${v.artifact.version} is affected with no fixes reported yet.`
 }
 
 
@@ -342,7 +269,7 @@ function grype_render_results(vulnerabilities, severity_cutoff_param) {
 }
 
 
-function grype_vulnerabilities_to_sarif(input_vulnerabilities, severity_cutoff_param, version) {
+function vulnerabilities_to_sarif(input_vulnerabilities, severity_cutoff_param, version) {
     let rawdata = fs.readFileSync(input_vulnerabilities);
     let parsed = JSON.parse(rawdata);
     let vulnerabilities = parsed.matches;
@@ -603,7 +530,7 @@ async function run() {
 function sarifGrypeGeneration(severity_cutoff_param, version){
     // sarif generate section
     const SARIF_FILE = "./results.sarif";
-    let sarifOutput = grype_vulnerabilities_to_sarif("./vulnerabilities.json", severity_cutoff_param, version);
+    let sarifOutput = vulnerabilities_to_sarif("./vulnerabilities.json", severity_cutoff_param, version);
     fs.writeFileSync(SARIF_FILE, JSON.stringify(sarifOutput, null, 2));
     core.setOutput('sarif', SARIF_FILE);
     // end sarif generate section

--- a/index.js
+++ b/index.js
@@ -230,11 +230,15 @@ function grype_render_rules(vulnerabilities) {
           result.push(
             {
                 "id": ruleID,
+                // Title of the SARIF report
                 "shortDescription": {
-                    "text": v.vulnerability.id + " Severity=" + v.vulnerability.severity + " Package=" + v.artifact.name + " Version=" + v.artifact.version
+                  "text": `${v.vulnerability.id} ${v.vulnerability.severity} vulnerability for ${v.artifact.name} package`
+                    //"text": v.vulnerability.id + " Severity=" + v.vulnerability.severity + " Package=" + v.artifact.name + " Version=" + v.artifact.version
                 },
+                // Subtitle of the SARIF report
                 "fullDescription": {
-                    "text": v.vulnerability.id + " Severity=" + v.vulnerability.severity + " Package=" + v.artifact.name + " Version=" + v.artifact.version
+                    //"text": v.vulnerability.id + " Severity=" + v.vulnerability.severity + " Package=" + v.artifact.name + " Version=" + v.artifact.version
+                  "text": `${v.vulnerability.description}`
                 },
                 "help": {
                     "text": "Vulnerability "+v.vulnerability.id+"\n"+


### PR DESCRIPTION
This pr addresses most of the items in issue #90 : 

* Changes the title to be as readable as possible
* Changes the sub-title to not be the same as the title, providing context. If the vulnerability has a description, that is provided as the sub-title. Otherwise a text is generated explaining the version affected and additionally if there is a fix for it or not
* The extra context gets reworded depending on analysis of a path or a container
* The container is now included as part of the rule ID so that it can get filtered.
* Removes dead code

Notable omissions from the original issue that this PR does not fix:

* Does not link back files/paths in the container for a reported vulnerability to files in the container
* Does not always populate the severity description from the CVE because this is not always available

Screenshots:

Container scan:
![Screen Shot 2021-03-26 at 1 50 37 PM](https://user-images.githubusercontent.com/317847/112672942-8543ea00-8e3a-11eb-9a18-be2600145271.png)


Path/directory scan:

![Screen Shot 2021-03-26 at 1 50 56 PM](https://user-images.githubusercontent.com/317847/112672900-76f5ce00-8e3a-11eb-9bc5-595eeff4e42f.png)


