### PR TITLE
github: automatically re-tag a major version release

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,15 @@
+name: Re-tag releases
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  actions-tagger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Actions-R-Us/actions-tagger@v2
+        env:
+          GITHUB_TOKEN: "${{ github.token }}"
+        with:
+          publish_latest_tag: true


### PR DESCRIPTION
Allows to automatically re-tag to a major release (e.g. `v2`) when a new release is done. This saves us from having to do this manually - which is error prone

Closes #40 