### PR TITLE
Fix incorrect release-drafter version template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,28 +1,28 @@
-name-template: '$RESOLVED_VERSION'
-tag-template: '$RESOLVED_VERSION'
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
 categories:
-  - title: '🚀 Features'
+  - title: "🚀 Features"
     labels:
-      - 'feature'
-      - 'enhancement'
-  - title: '🐛 Bug Fixes'
+      - "feature"
+      - "enhancement"
+  - title: "🐛 Bug Fixes"
     labels:
-      - 'fix'
-      - 'bugfix'
-      - 'bug'
-change-template: '- $TITLE (#$NUMBER)'
+      - "fix"
+      - "bugfix"
+      - "bug"
+change-template: "- $TITLE (#$NUMBER)"
 version-resolver:
   major:
     labels:
-      - 'major'
+      - "major"
   minor:
     labels:
-      - 'minor'
+      - "minor"
   patch:
     labels:
-      - 'patch'
+      - "patch"
   default: patch
 template: |
-  ## New in scan-action $RESOLVED_VERSION
+  ## New in scan-action v$RESOLVED_VERSION
 
   $CHANGES


### PR DESCRIPTION
The [release-drafter action](https://github.com/marketplace/actions/release-drafter) keeps [a draft release](https://github.com/anchore/scan-action/releases/tag/untagged-a8560493d8ec45883340) up to date with information about PRs that have been merged to main. It was using `#.#.#` as the version, but should have been using `v#.#.#`, according to Github Actions' recommendations [and it's own example template](https://github.com/marketplace/actions/release-drafter#example). I also added the `major` label with this PR, as this is what it [apparently uses to bump major versions](https://github.com/marketplace/actions/release-drafter#version-resolver)