### PR TITLE
Pin Grype db for tests #120

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,10 @@ jobs:
           for distro in alpine centos debian; do
             docker buildx imagetools inspect localhost:5000/match-coverage/$distro:latest
           done
+      - run: |
+          echo Downloading a pinned Grype DB for testing...
+          mkdir -p grype-db/3
+          curl -sL https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v3_2021-09-10T08:18:17Z.tar.gz | tar zxf - -C grype-db/3
       - run: npm ci
       - run: npm audit --production
       - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
           curl -sL https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v3_2021-09-10T08:18:17Z.tar.gz | tar zxf - -C grype-db/3
       - run: npm ci
       - run: npm audit --production
-      - run: npm test
+      - run: GRYPE_DB_AUTO_UPDATE=false GRYPE_DB_CACHE_DIR=./grype-db npm test
 
   functional:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,9 @@ typings/
 /venv/*
 /tests/functional/__pycache__/*
 
+# grype db for tests
+/grype-db
+
 # Action temporary files
 results.sarif
 vulnerabilities.json

--- a/.jest/setEnvVars.js
+++ b/.jest/setEnvVars.js
@@ -1,4 +1,2 @@
 process.env["RUNNER_TOOL_CACHE"] = "/tmp/actions/cache";
 process.env["RUNNER_TEMP"] = "/tmp/actions/temp";
-process.env["GRYPE_DB_AUTO_UPDATE"] = "false";
-process.env["GRYPE_DB_CACHE_DIR"] = "./grype-db";

--- a/.jest/setEnvVars.js
+++ b/.jest/setEnvVars.js
@@ -1,2 +1,4 @@
-process.env['RUNNER_TOOL_CACHE'] = '/tmp/actions/cache';
-process.env['RUNNER_TEMP'] = '/tmp/actions/temp';
+process.env["RUNNER_TOOL_CACHE"] = "/tmp/actions/cache";
+process.env["RUNNER_TEMP"] = "/tmp/actions/temp";
+process.env["GRYPE_DB_AUTO_UPDATE"] = "false";
+process.env["GRYPE_DB_CACHE_DIR"] = "./grype-db";

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The simplest workflow for scanning a `localbuild/testimage` container:
     load: true
 
  - name: Scan image
-   uses: anchore/scan-action@v2
+   uses: anchore/scan-action@v3
    with:
      image: "localbuild/testimage:latest"
 ```
@@ -62,7 +62,7 @@ To scan a directory, add the following step:
 
 ```yaml
 - name: Scan current project
-  uses: anchore/scan-action@v2
+  uses: anchore/scan-action@v3
   with:
     path: "."
 ```
@@ -77,7 +77,7 @@ With a different severity level:
 
 ```yaml
 - name: Scan image
-  uses: anchore/scan-action@v2
+  uses: anchore/scan-action@v3
   with:
     image: "localbuild/testimage:latest"
     fail-build: true
@@ -88,7 +88,7 @@ Optionally, change the `fail-build` field to `false` to avoid failing the build 
 
 ```yaml
 - name: Scan image
-  uses: anchore/scan-action@v2
+  uses: anchore/scan-action@v3
   with:
     image: "localbuild/testimage:latest"
     fail-build: false
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build the container image
         run: docker build . --file Dockerfile --tag localbuild/testimage:latest
-      - uses: anchore/scan-action@v2
+      - uses: anchore/scan-action@v3
         with:
           image: "localbuild/testimage:latest"
           fail-build: true
@@ -147,7 +147,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build the Container image
         run: docker build . --file Dockerfile --tag localbuild/testimage:latest
-      - uses: anchore/scan-action@v2
+      - uses: anchore/scan-action@v3
         id: scan
         with:
           image: "localbuild/testimage:latest"

--- a/dist/index.js
+++ b/dist/index.js
@@ -513,7 +513,16 @@ async function runScan({
     },
   });
 
-  const cmdOpts = {
+  core.info("\nAnalyzing: " + source);
+
+  core.info(`Executing: ${cmd} ` + cmdArgs.join(" "));
+
+  const exitCode = await exec(cmd, cmdArgs, {
+    env: {
+      GRYPE_CHECK_FOR_APP_UPDATE: "false",
+      GRYPE_DB_AUTO_UPDATE: process.env.GRYPE_DB_AUTO_UPDATE,
+      GRYPE_DB_CACHE_DIR: process.env.GRYPE_DB_CACHE_DIR,
+    },
     ignoreReturnCode: true,
     outStream,
     listeners: {
@@ -521,13 +530,7 @@ async function runScan({
         cmdOutput += data.toString();
       },
     },
-  };
-
-  core.info("\nAnalyzing: " + source);
-
-  core.info(`Executing: ${cmd} ` + cmdArgs.join(" "));
-
-  const exitCode = await exec(cmd, cmdArgs, cmdOpts);
+  });
 
   if (core.isDebug()) {
     core.debug("Grype output:");

--- a/dist/index.js
+++ b/dist/index.js
@@ -520,8 +520,6 @@ async function runScan({
   const exitCode = await exec(cmd, cmdArgs, {
     env: {
       GRYPE_CHECK_FOR_APP_UPDATE: "false",
-      GRYPE_DB_AUTO_UPDATE: process.env.GRYPE_DB_AUTO_UPDATE || "",
-      GRYPE_DB_CACHE_DIR: process.env.GRYPE_DB_CACHE_DIR || "",
     },
     ignoreReturnCode: true,
     outStream,

--- a/dist/index.js
+++ b/dist/index.js
@@ -520,8 +520,8 @@ async function runScan({
   const exitCode = await exec(cmd, cmdArgs, {
     env: {
       GRYPE_CHECK_FOR_APP_UPDATE: "false",
-      GRYPE_DB_AUTO_UPDATE: process.env.GRYPE_DB_AUTO_UPDATE,
-      GRYPE_DB_CACHE_DIR: process.env.GRYPE_DB_CACHE_DIR,
+      GRYPE_DB_AUTO_UPDATE: process.env.GRYPE_DB_AUTO_UPDATE || "",
+      GRYPE_DB_CACHE_DIR: process.env.GRYPE_DB_CACHE_DIR || "",
     },
     ignoreReturnCode: true,
     outStream,

--- a/dist/index.js
+++ b/dist/index.js
@@ -504,8 +504,8 @@ async function runScan({
   }
   cmdArgs.push(source);
 
-  // This /dev/null writable stream is required so the entire contents
-  // of the SBOM is not written to the GitHub action log. the listener below
+  // This /dev/null writable stream is required so the entire Grype output
+  // is not written to the GitHub action log. the listener below
   // will actually capture the output
   const outStream = new stream.Writable({
     write(buffer, encoding, next) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -9,6 +9,7 @@ const cache = __webpack_require__(784);
 const core = __webpack_require__(186);
 const { exec } = __webpack_require__(514);
 const fs = __webpack_require__(747);
+const stream = __webpack_require__(413);
 
 const grypeBinary = "grype";
 const grypeVersion = "0.17.0";
@@ -502,21 +503,31 @@ async function runScan({
     cmdArgs.push(severityCutoff.toLowerCase());
   }
   cmdArgs.push(source);
-  const cmdOpts = {};
-  cmdOpts.listeners = {
-    stdout: (data = Buffer) => {
-      cmdOutput += data.toString();
+
+  // This /dev/null writable stream is required so the entire contents
+  // of the SBOM is not written to the GitHub action log. the listener below
+  // will actually capture the output
+  const outStream = new stream.Writable({
+    write(buffer, encoding, next) {
+      next();
+    },
+  });
+
+  const cmdOpts = {
+    ignoreReturnCode: true,
+    outStream,
+    listeners: {
+      stdout: (data = Buffer) => {
+        cmdOutput += data.toString();
+      },
     },
   };
 
-  cmdOpts.ignoreReturnCode = true;
-
   core.info("\nAnalyzing: " + source);
 
-  const exitCode = await core.group("Grype Output", () => {
-    core.info(`Executing: ${cmd} ` + cmdArgs.join(" "));
-    return exec(cmd, cmdArgs, cmdOpts);
-  });
+  core.info(`Executing: ${cmd} ` + cmdArgs.join(" "));
+
+  const exitCode = await exec(cmd, cmdArgs, cmdOpts);
 
   let grypeVulnerabilities = JSON.parse(cmdOutput);
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -529,6 +529,11 @@ async function runScan({
 
   const exitCode = await exec(cmd, cmdArgs, cmdOpts);
 
+  if (core.isDebug()) {
+    core.debug("Grype output:");
+    core.debug(cmdOutput);
+  }
+
   let grypeVulnerabilities = JSON.parse(cmdOutput);
 
   if (acsReportEnable) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -513,14 +513,7 @@ async function runScan({
     },
   });
 
-  core.info("\nAnalyzing: " + source);
-
-  core.info(`Executing: ${cmd} ` + cmdArgs.join(" "));
-
-  const exitCode = await exec(cmd, cmdArgs, {
-    env: {
-      GRYPE_CHECK_FOR_APP_UPDATE: "false",
-    },
+  const cmdOpts = {
     ignoreReturnCode: true,
     outStream,
     listeners: {
@@ -528,7 +521,13 @@ async function runScan({
         cmdOutput += data.toString();
       },
     },
-  });
+  };
+
+  core.info("\nAnalyzing: " + source);
+
+  core.info(`Executing: ${cmd} ` + cmdArgs.join(" "));
+
+  const exitCode = await exec(cmd, cmdArgs, cmdOpts);
 
   if (core.isDebug()) {
     core.debug("Grype output:");

--- a/index.js
+++ b/index.js
@@ -506,14 +506,7 @@ async function runScan({
     },
   });
 
-  core.info("\nAnalyzing: " + source);
-
-  core.info(`Executing: ${cmd} ` + cmdArgs.join(" "));
-
-  const exitCode = await exec(cmd, cmdArgs, {
-    env: {
-      GRYPE_CHECK_FOR_APP_UPDATE: "false",
-    },
+  const cmdOpts = {
     ignoreReturnCode: true,
     outStream,
     listeners: {
@@ -521,7 +514,13 @@ async function runScan({
         cmdOutput += data.toString();
       },
     },
-  });
+  };
+
+  core.info("\nAnalyzing: " + source);
+
+  core.info(`Executing: ${cmd} ` + cmdArgs.join(" "));
+
+  const exitCode = await exec(cmd, cmdArgs, cmdOpts);
 
   if (core.isDebug()) {
     core.debug("Grype output:");

--- a/index.js
+++ b/index.js
@@ -513,8 +513,6 @@ async function runScan({
   const exitCode = await exec(cmd, cmdArgs, {
     env: {
       GRYPE_CHECK_FOR_APP_UPDATE: "false",
-      GRYPE_DB_AUTO_UPDATE: process.env.GRYPE_DB_AUTO_UPDATE || "",
-      GRYPE_DB_CACHE_DIR: process.env.GRYPE_DB_CACHE_DIR || "",
     },
     ignoreReturnCode: true,
     outStream,

--- a/index.js
+++ b/index.js
@@ -513,8 +513,8 @@ async function runScan({
   const exitCode = await exec(cmd, cmdArgs, {
     env: {
       GRYPE_CHECK_FOR_APP_UPDATE: "false",
-      GRYPE_DB_AUTO_UPDATE: process.env.GRYPE_DB_AUTO_UPDATE,
-      GRYPE_DB_CACHE_DIR: process.env.GRYPE_DB_CACHE_DIR,
+      GRYPE_DB_AUTO_UPDATE: process.env.GRYPE_DB_AUTO_UPDATE || "",
+      GRYPE_DB_CACHE_DIR: process.env.GRYPE_DB_CACHE_DIR || "",
     },
     ignoreReturnCode: true,
     outStream,

--- a/index.js
+++ b/index.js
@@ -506,7 +506,16 @@ async function runScan({
     },
   });
 
-  const cmdOpts = {
+  core.info("\nAnalyzing: " + source);
+
+  core.info(`Executing: ${cmd} ` + cmdArgs.join(" "));
+
+  const exitCode = await exec(cmd, cmdArgs, {
+    env: {
+      GRYPE_CHECK_FOR_APP_UPDATE: "false",
+      GRYPE_DB_AUTO_UPDATE: process.env.GRYPE_DB_AUTO_UPDATE,
+      GRYPE_DB_CACHE_DIR: process.env.GRYPE_DB_CACHE_DIR,
+    },
     ignoreReturnCode: true,
     outStream,
     listeners: {
@@ -514,13 +523,7 @@ async function runScan({
         cmdOutput += data.toString();
       },
     },
-  };
-
-  core.info("\nAnalyzing: " + source);
-
-  core.info(`Executing: ${cmd} ` + cmdArgs.join(" "));
-
-  const exitCode = await exec(cmd, cmdArgs, cmdOpts);
+  });
 
   if (core.isDebug()) {
     core.debug("Grype output:");

--- a/index.js
+++ b/index.js
@@ -522,6 +522,11 @@ async function runScan({
 
   const exitCode = await exec(cmd, cmdArgs, cmdOpts);
 
+  if (core.isDebug()) {
+    core.debug("Grype output:");
+    core.debug(cmdOutput);
+  }
+
   let grypeVulnerabilities = JSON.parse(cmdOutput);
 
   if (acsReportEnable) {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const cache = require("@actions/tool-cache");
 const core = require("@actions/core");
 const { exec } = require("@actions/exec");
 const fs = require("fs");
+const stream = require("stream");
 
 const grypeBinary = "grype";
 const grypeVersion = "0.17.0";
@@ -495,21 +496,31 @@ async function runScan({
     cmdArgs.push(severityCutoff.toLowerCase());
   }
   cmdArgs.push(source);
-  const cmdOpts = {};
-  cmdOpts.listeners = {
-    stdout: (data = Buffer) => {
-      cmdOutput += data.toString();
+
+  // This /dev/null writable stream is required so the entire contents
+  // of the SBOM is not written to the GitHub action log. the listener below
+  // will actually capture the output
+  const outStream = new stream.Writable({
+    write(buffer, encoding, next) {
+      next();
+    },
+  });
+
+  const cmdOpts = {
+    ignoreReturnCode: true,
+    outStream,
+    listeners: {
+      stdout: (data = Buffer) => {
+        cmdOutput += data.toString();
+      },
     },
   };
 
-  cmdOpts.ignoreReturnCode = true;
-
   core.info("\nAnalyzing: " + source);
 
-  const exitCode = await core.group("Grype Output", () => {
-    core.info(`Executing: ${cmd} ` + cmdArgs.join(" "));
-    return exec(cmd, cmdArgs, cmdOpts);
-  });
+  core.info(`Executing: ${cmd} ` + cmdArgs.join(" "));
+
+  const exitCode = await exec(cmd, cmdArgs, cmdOpts);
 
   let grypeVulnerabilities = JSON.parse(cmdOutput);
 

--- a/index.js
+++ b/index.js
@@ -497,8 +497,8 @@ async function runScan({
   }
   cmdArgs.push(source);
 
-  // This /dev/null writable stream is required so the entire contents
-  // of the SBOM is not written to the GitHub action log. the listener below
+  // This /dev/null writable stream is required so the entire Grype output
+  // is not written to the GitHub action log. the listener below
   // will actually capture the output
   const outStream = new stream.Writable({
     write(buffer, encoding, next) {

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,4 @@ module.exports = {
   setupFiles: ["<rootDir>/.jest/setEnvVars.js"],
   verbose: true,
   testPathIgnorePatterns: ["action.test.js"],
-  reporters: [["jest-summary-reporter", { failuresOnly: false }]],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4272,15 +4272,6 @@
         }
       }
     },
-    "jest-summary-reporter": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/jest-summary-reporter/-/jest-summary-reporter-0.0.2.tgz",
-      "integrity": "sha512-rZ3ThO57l+ZJCxF74cXIGQU3cV9I7bSBe1ElBp0taE3x2JghgD69bNCKt0LvpVQX5azTRHG7LmcjIpwriVnTng==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.4.1"
-      }
-    },
     "jest-util": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "eslint": "^6.8.0",
     "husky": "^3.1.0",
     "jest": "^25.5.4",
-    "jest-summary-reporter": "0.0.2",
     "prettier": "^2.3.2",
     "pretty-quick": "^3.1.1"
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "lint": "eslint index.js",
     "test": "eslint index.js && jest",
+    "update-snapshots": "eslint index.js && jest --updateSnapshot",
     "build": "ncc build ./index.js",
     "precommit": "pretty-quick --staged && npm run build && git add dist/",
     "prettier": "prettier -w index.js"

--- a/tests/__snapshots__/sarif_output.test.js.snap
+++ b/tests/__snapshots__/sarif_output.test.js.snap
@@ -954,10 +954,10 @@ Link: [CVE-2014-6055](https://nvd.nist.gov/vuln/detail/CVE-2014-6055)",
                 "markdown": "**Vulnerability CVE-2016-9941**
 | Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-|High|libvncserver|0.9.9|0.9.11-r0|apk|/lib/apk/db/installed|unknown|[CVE-2016-9941](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-9941)|
+|Critical|libvncserver|0.9.9|0.9.11-r0|apk|/lib/apk/db/installed|unknown|[CVE-2016-9941](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-9941)|
 ",
                 "text": "Vulnerability CVE-2016-9941
-Severity: High
+Severity: Critical
 Package: libvncserver
 Version: 0.9.9
 Fix Version: 0.9.11-r0
@@ -968,7 +968,7 @@ Link: [CVE-2016-9941](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-994
               },
               "id": "ANCHOREVULN_CVE-2016-9941_apk_libvncserver_0.9.9",
               "shortDescription": Object {
-                "text": "CVE-2016-9941 High vulnerability for libvncserver package",
+                "text": "CVE-2016-9941 Critical vulnerability for libvncserver package",
               },
             },
             Object {
@@ -979,10 +979,10 @@ Link: [CVE-2016-9941](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-994
                 "markdown": "**Vulnerability CVE-2016-9942**
 | Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-|High|libvncserver|0.9.9|0.9.11-r0|apk|/lib/apk/db/installed|unknown|[CVE-2016-9942](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-9942)|
+|Critical|libvncserver|0.9.9|0.9.11-r0|apk|/lib/apk/db/installed|unknown|[CVE-2016-9942](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-9942)|
 ",
                 "text": "Vulnerability CVE-2016-9942
-Severity: High
+Severity: Critical
 Package: libvncserver
 Version: 0.9.9
 Fix Version: 0.9.11-r0
@@ -993,7 +993,7 @@ Link: [CVE-2016-9942](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-994
               },
               "id": "ANCHOREVULN_CVE-2016-9942_apk_libvncserver_0.9.9",
               "shortDescription": Object {
-                "text": "CVE-2016-9942 High vulnerability for libvncserver package",
+                "text": "CVE-2016-9942 Critical vulnerability for libvncserver package",
               },
             },
             Object {
@@ -1004,10 +1004,10 @@ Link: [CVE-2016-9942](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-994
                 "markdown": "**Vulnerability CVE-2018-7225**
 | Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-|High|libvncserver|0.9.9|0.9.11-r2|apk|/lib/apk/db/installed|unknown|[CVE-2018-7225](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7225)|
+|Critical|libvncserver|0.9.9|0.9.11-r2|apk|/lib/apk/db/installed|unknown|[CVE-2018-7225](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7225)|
 ",
                 "text": "Vulnerability CVE-2018-7225
-Severity: High
+Severity: Critical
 Package: libvncserver
 Version: 0.9.9
 Fix Version: 0.9.11-r2
@@ -1018,7 +1018,7 @@ Link: [CVE-2018-7225](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-722
               },
               "id": "ANCHOREVULN_CVE-2018-7225_apk_libvncserver_0.9.9",
               "shortDescription": Object {
-                "text": "CVE-2018-7225 High vulnerability for libvncserver package",
+                "text": "CVE-2018-7225 Critical vulnerability for libvncserver package",
               },
             },
             Object {
@@ -1029,10 +1029,10 @@ Link: [CVE-2018-7225](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-722
                 "markdown": "**Vulnerability CVE-2019-15681**
 | Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-|Medium|libvncserver|0.9.9|0.9.12-r1|apk|/lib/apk/db/installed|unknown|[CVE-2019-15681](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15681)|
+|High|libvncserver|0.9.9|0.9.12-r1|apk|/lib/apk/db/installed|unknown|[CVE-2019-15681](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15681)|
 ",
                 "text": "Vulnerability CVE-2019-15681
-Severity: Medium
+Severity: High
 Package: libvncserver
 Version: 0.9.9
 Fix Version: 0.9.12-r1
@@ -1043,7 +1043,7 @@ Link: [CVE-2019-15681](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15
               },
               "id": "ANCHOREVULN_CVE-2019-15681_apk_libvncserver_0.9.9",
               "shortDescription": Object {
-                "text": "CVE-2019-15681 Medium vulnerability for libvncserver package",
+                "text": "CVE-2019-15681 High vulnerability for libvncserver package",
               },
             },
             Object {
@@ -1054,10 +1054,10 @@ Link: [CVE-2019-15681](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15
                 "markdown": "**Vulnerability CVE-2019-20839**
 | Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-|Medium|libvncserver|0.9.9|0.9.13-r0|apk|/lib/apk/db/installed|unknown|[CVE-2019-20839](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-20839)|
+|High|libvncserver|0.9.9|0.9.13-r0|apk|/lib/apk/db/installed|unknown|[CVE-2019-20839](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-20839)|
 ",
                 "text": "Vulnerability CVE-2019-20839
-Severity: Medium
+Severity: High
 Package: libvncserver
 Version: 0.9.9
 Fix Version: 0.9.13-r0
@@ -1068,7 +1068,7 @@ Link: [CVE-2019-20839](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-20
               },
               "id": "ANCHOREVULN_CVE-2019-20839_apk_libvncserver_0.9.9",
               "shortDescription": Object {
-                "text": "CVE-2019-20839 Medium vulnerability for libvncserver package",
+                "text": "CVE-2019-20839 High vulnerability for libvncserver package",
               },
             },
             Object {
@@ -1079,10 +1079,10 @@ Link: [CVE-2019-20839](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-20
                 "markdown": "**Vulnerability CVE-2019-20840**
 | Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-|Medium|libvncserver|0.9.9|0.9.13-r0|apk|/lib/apk/db/installed|unknown|[CVE-2019-20840](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-20840)|
+|High|libvncserver|0.9.9|0.9.13-r0|apk|/lib/apk/db/installed|unknown|[CVE-2019-20840](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-20840)|
 ",
                 "text": "Vulnerability CVE-2019-20840
-Severity: Medium
+Severity: High
 Package: libvncserver
 Version: 0.9.9
 Fix Version: 0.9.13-r0
@@ -1093,7 +1093,7 @@ Link: [CVE-2019-20840](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-20
               },
               "id": "ANCHOREVULN_CVE-2019-20840_apk_libvncserver_0.9.9",
               "shortDescription": Object {
-                "text": "CVE-2019-20840 Medium vulnerability for libvncserver package",
+                "text": "CVE-2019-20840 High vulnerability for libvncserver package",
               },
             },
             Object {
@@ -1104,10 +1104,10 @@ Link: [CVE-2019-20840](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-20
                 "markdown": "**Vulnerability CVE-2020-14397**
 | Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-|Medium|libvncserver|0.9.9|0.9.13-r0|apk|/lib/apk/db/installed|unknown|[CVE-2020-14397](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14397)|
+|High|libvncserver|0.9.9|0.9.13-r0|apk|/lib/apk/db/installed|unknown|[CVE-2020-14397](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14397)|
 ",
                 "text": "Vulnerability CVE-2020-14397
-Severity: Medium
+Severity: High
 Package: libvncserver
 Version: 0.9.9
 Fix Version: 0.9.13-r0
@@ -1118,7 +1118,7 @@ Link: [CVE-2020-14397](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14
               },
               "id": "ANCHOREVULN_CVE-2020-14397_apk_libvncserver_0.9.9",
               "shortDescription": Object {
-                "text": "CVE-2020-14397 Medium vulnerability for libvncserver package",
+                "text": "CVE-2020-14397 High vulnerability for libvncserver package",
               },
             },
             Object {
@@ -1129,10 +1129,10 @@ Link: [CVE-2020-14397](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14
                 "markdown": "**Vulnerability CVE-2020-14399**
 | Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-|Medium|libvncserver|0.9.9|0.9.13-r0|apk|/lib/apk/db/installed|unknown|[CVE-2020-14399](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14399)|
+|High|libvncserver|0.9.9|0.9.13-r0|apk|/lib/apk/db/installed|unknown|[CVE-2020-14399](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14399)|
 ",
                 "text": "Vulnerability CVE-2020-14399
-Severity: Medium
+Severity: High
 Package: libvncserver
 Version: 0.9.9
 Fix Version: 0.9.13-r0
@@ -1143,7 +1143,7 @@ Link: [CVE-2020-14399](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14
               },
               "id": "ANCHOREVULN_CVE-2020-14399_apk_libvncserver_0.9.9",
               "shortDescription": Object {
-                "text": "CVE-2020-14399 Medium vulnerability for libvncserver package",
+                "text": "CVE-2020-14399 High vulnerability for libvncserver package",
               },
             },
             Object {
@@ -1154,10 +1154,10 @@ Link: [CVE-2020-14399](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14
                 "markdown": "**Vulnerability CVE-2020-14400**
 | Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-|Medium|libvncserver|0.9.9|0.9.13-r0|apk|/lib/apk/db/installed|unknown|[CVE-2020-14400](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14400)|
+|High|libvncserver|0.9.9|0.9.13-r0|apk|/lib/apk/db/installed|unknown|[CVE-2020-14400](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14400)|
 ",
                 "text": "Vulnerability CVE-2020-14400
-Severity: Medium
+Severity: High
 Package: libvncserver
 Version: 0.9.9
 Fix Version: 0.9.13-r0
@@ -1168,7 +1168,7 @@ Link: [CVE-2020-14400](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14
               },
               "id": "ANCHOREVULN_CVE-2020-14400_apk_libvncserver_0.9.9",
               "shortDescription": Object {
-                "text": "CVE-2020-14400 Medium vulnerability for libvncserver package",
+                "text": "CVE-2020-14400 High vulnerability for libvncserver package",
               },
             },
             Object {
@@ -1304,10 +1304,10 @@ Link: [CVE-2020-14405](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14
                 "markdown": "**Vulnerability CVE-2020-25708**
 | Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-|Medium|libvncserver|0.9.9|0.9.13-r0|apk|/lib/apk/db/installed|unknown|[CVE-2020-25708](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25708)|
+|High|libvncserver|0.9.9|0.9.13-r0|apk|/lib/apk/db/installed|unknown|[CVE-2020-25708](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25708)|
 ",
                 "text": "Vulnerability CVE-2020-25708
-Severity: Medium
+Severity: High
 Package: libvncserver
 Version: 0.9.9
 Fix Version: 0.9.13-r0
@@ -1318,7 +1318,7 @@ Link: [CVE-2020-25708](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25
               },
               "id": "ANCHOREVULN_CVE-2020-25708_apk_libvncserver_0.9.9",
               "shortDescription": Object {
-                "text": "CVE-2020-25708 Medium vulnerability for libvncserver package",
+                "text": "CVE-2020-25708 High vulnerability for libvncserver package",
               },
             },
           ],
@@ -1775,6 +1775,126 @@ Object {
             "id": "default",
             "text": "The path tests/fixtures/npm-project/package-lock.json reports tar at version 6.1.0  which would result in a vulnerable (npm) package installed",
           },
+          "ruleId": "ANCHOREVULN_GHSA-5955-9wpr-37jh_npm_tar_6.1.0",
+          "ruleIndex": 0,
+          "suppressions": Array [
+            Object {
+              "kind": "external",
+            },
+          ],
+        },
+        Object {
+          "analysisTarget": Object {
+            "uri": "tests/fixtures/npm-project/package-lock.json",
+          },
+          "baselineState": "unchanged",
+          "level": "error",
+          "locations": Array [
+            Object {
+              "logicalLocations": Array [
+                Object {
+                  "fullyQualifiedName": "dockerfile",
+                },
+              ],
+              "physicalLocation": Object {
+                "artifactLocation": Object {
+                  "uri": "tests/fixtures/npm-project/package-lock.json",
+                },
+                "region": Object {
+                  "byteLength": 1,
+                  "byteOffset": 1,
+                  "endColumn": 1,
+                  "endLine": 1,
+                  "startColumn": 1,
+                  "startLine": 1,
+                },
+              },
+            },
+          ],
+          "message": Object {
+            "id": "default",
+            "text": "The path tests/fixtures/npm-project/package-lock.json reports tar at version 6.1.0  which would result in a vulnerable (npm) package installed",
+          },
+          "ruleId": "ANCHOREVULN_GHSA-9r2w-394v-53qc_npm_tar_6.1.0",
+          "ruleIndex": 0,
+          "suppressions": Array [
+            Object {
+              "kind": "external",
+            },
+          ],
+        },
+        Object {
+          "analysisTarget": Object {
+            "uri": "tests/fixtures/npm-project/package-lock.json",
+          },
+          "baselineState": "unchanged",
+          "level": "error",
+          "locations": Array [
+            Object {
+              "logicalLocations": Array [
+                Object {
+                  "fullyQualifiedName": "dockerfile",
+                },
+              ],
+              "physicalLocation": Object {
+                "artifactLocation": Object {
+                  "uri": "tests/fixtures/npm-project/package-lock.json",
+                },
+                "region": Object {
+                  "byteLength": 1,
+                  "byteOffset": 1,
+                  "endColumn": 1,
+                  "endLine": 1,
+                  "startColumn": 1,
+                  "startLine": 1,
+                },
+              },
+            },
+          ],
+          "message": Object {
+            "id": "default",
+            "text": "The path tests/fixtures/npm-project/package-lock.json reports tar at version 6.1.0  which would result in a vulnerable (npm) package installed",
+          },
+          "ruleId": "ANCHOREVULN_GHSA-qq89-hq3f-393p_npm_tar_6.1.0",
+          "ruleIndex": 0,
+          "suppressions": Array [
+            Object {
+              "kind": "external",
+            },
+          ],
+        },
+        Object {
+          "analysisTarget": Object {
+            "uri": "tests/fixtures/npm-project/package-lock.json",
+          },
+          "baselineState": "unchanged",
+          "level": "error",
+          "locations": Array [
+            Object {
+              "logicalLocations": Array [
+                Object {
+                  "fullyQualifiedName": "dockerfile",
+                },
+              ],
+              "physicalLocation": Object {
+                "artifactLocation": Object {
+                  "uri": "tests/fixtures/npm-project/package-lock.json",
+                },
+                "region": Object {
+                  "byteLength": 1,
+                  "byteOffset": 1,
+                  "endColumn": 1,
+                  "endLine": 1,
+                  "startColumn": 1,
+                  "startLine": 1,
+                },
+              },
+            },
+          ],
+          "message": Object {
+            "id": "default",
+            "text": "The path tests/fixtures/npm-project/package-lock.json reports tar at version 6.1.0  which would result in a vulnerable (npm) package installed",
+          },
           "ruleId": "ANCHOREVULN_GHSA-r628-mhmh-qjhw_npm_tar_6.1.0",
           "ruleIndex": 0,
           "suppressions": Array [
@@ -1813,6 +1933,81 @@ Link: [GHSA-3jfq-g458-7qm9](https://github.com/advisories/GHSA-3jfq-g458-7qm9)",
               "id": "ANCHOREVULN_GHSA-3jfq-g458-7qm9_npm_tar_6.1.0",
               "shortDescription": Object {
                 "text": "GHSA-3jfq-g458-7qm9 High vulnerability for tar package",
+              },
+            },
+            Object {
+              "fullDescription": Object {
+                "text": "Arbitrary File Creation/Overwrite on Windows via insufficient relative path sanitization",
+              },
+              "help": Object {
+                "markdown": "**Vulnerability GHSA-5955-9wpr-37jh**
+| Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+|High|tar|6.1.0|6.1.9|npm|tests/fixtures/npm-project/package-lock.json|unknown|[GHSA-5955-9wpr-37jh](https://github.com/advisories/GHSA-5955-9wpr-37jh)|
+",
+                "text": "Vulnerability GHSA-5955-9wpr-37jh
+Severity: High
+Package: tar
+Version: 6.1.0
+Fix Version: 6.1.9
+Type: npm
+Location: tests/fixtures/npm-project/package-lock.json
+Data Namespace: unknown
+Link: [GHSA-5955-9wpr-37jh](https://github.com/advisories/GHSA-5955-9wpr-37jh)",
+              },
+              "id": "ANCHOREVULN_GHSA-5955-9wpr-37jh_npm_tar_6.1.0",
+              "shortDescription": Object {
+                "text": "GHSA-5955-9wpr-37jh High vulnerability for tar package",
+              },
+            },
+            Object {
+              "fullDescription": Object {
+                "text": "Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning using symbolic links",
+              },
+              "help": Object {
+                "markdown": "**Vulnerability GHSA-9r2w-394v-53qc**
+| Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+|High|tar|6.1.0|6.1.7|npm|tests/fixtures/npm-project/package-lock.json|unknown|[GHSA-9r2w-394v-53qc](https://github.com/advisories/GHSA-9r2w-394v-53qc)|
+",
+                "text": "Vulnerability GHSA-9r2w-394v-53qc
+Severity: High
+Package: tar
+Version: 6.1.0
+Fix Version: 6.1.7
+Type: npm
+Location: tests/fixtures/npm-project/package-lock.json
+Data Namespace: unknown
+Link: [GHSA-9r2w-394v-53qc](https://github.com/advisories/GHSA-9r2w-394v-53qc)",
+              },
+              "id": "ANCHOREVULN_GHSA-9r2w-394v-53qc_npm_tar_6.1.0",
+              "shortDescription": Object {
+                "text": "GHSA-9r2w-394v-53qc High vulnerability for tar package",
+              },
+            },
+            Object {
+              "fullDescription": Object {
+                "text": "Arbitrary File Creation/Overwrite via insufficient symlink protection due to directory cache poisoning using symbolic links",
+              },
+              "help": Object {
+                "markdown": "**Vulnerability GHSA-qq89-hq3f-393p**
+| Severity | Package | Version | Fix Version | Type | Location | Data Namespace | Link |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+|High|tar|6.1.0|6.1.9|npm|tests/fixtures/npm-project/package-lock.json|unknown|[GHSA-qq89-hq3f-393p](https://github.com/advisories/GHSA-qq89-hq3f-393p)|
+",
+                "text": "Vulnerability GHSA-qq89-hq3f-393p
+Severity: High
+Package: tar
+Version: 6.1.0
+Fix Version: 6.1.9
+Type: npm
+Location: tests/fixtures/npm-project/package-lock.json
+Data Namespace: unknown
+Link: [GHSA-qq89-hq3f-393p](https://github.com/advisories/GHSA-qq89-hq3f-393p)",
+              },
+              "id": "ANCHOREVULN_GHSA-qq89-hq3f-393p_npm_tar_6.1.0",
+              "shortDescription": Object {
+                "text": "GHSA-qq89-hq3f-393p High vulnerability for tar package",
               },
             },
             Object {


### PR DESCRIPTION
Download and use a static Grype database for snapshot testing. This started out because I missed some documentation referencing `v2` release instead of `v3` and had failed tests, so went down a bit of a rabbit hole making the tests reproducible and easier to understand by reverting back to the normal Jest reporter and removing the mountains of Grype output dumped to the logs.