### PR TITLE
Add sub-action to download Grype

### DIFF
--- a/GrypeVersion.js
+++ b/GrypeVersion.js
@@ -1,1 +1,1 @@
-exports.GRYPE_VERSION = "0.34.4";
+exports.GRYPE_VERSION = "v0.34.4";

--- a/GrypeVersion.js
+++ b/GrypeVersion.js
@@ -1,0 +1,1 @@
+exports.GRYPE_VERSION = "0.34.4";

--- a/README.md
+++ b/README.md
@@ -174,6 +174,33 @@ You may add a `.grype.yaml` file at your repository root
 for more [Grype configuration](https://github.com/anchore/grype#configuration)
 such as [ignoring certain matches](https://github.com/anchore/grype#specifying-matches-to-ignore).
 
+## anchore/scan-action/download-grype
+
+A sub-action to [download Grype](download-grype/action.yml).
+
+Input parameters:
+
+| Parameter       | Description                                                                                                  | Default |
+| --------------- | ------------------------------------------------------------------------------------------------------------ | ------- |
+| `grype-version` | An optional Grype version to download, defaults to the pinned version in [GrypeVersion.js](GrypeVersion.js). |         |
+
+Output parameters:
+
+| Parameter | Description                                                          |
+| --------- | -------------------------------------------------------------------- |
+| `cmd`     | a reference to the [Grype](https://github.com/anchore/grype) binary. |
+
+`cmd` can be referenced in a workflow like other output parameters:
+`${{ steps.<step-id>.outputs.cmd }}`
+
+Example usage:
+
+```yaml
+- uses: anchore/scan-action/download-grype
+  id: grype
+- run: ${{steps.grype.outputs.cmd}} dir:.
+```
+
 ## Contributing
 
 We love contributions, feedback, and bug reports. For issues with the invocation of this action, file [issues](https://github.com/anchore/scan-action/issues) in this repository.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Output parameters:
 Example usage:
 
 ```yaml
-- uses: anchore/scan-action/download-grype
+- uses: anchore/scan-action/download-grype@v3
   id: grype
 - run: ${{steps.grype.outputs.cmd}} dir:.
 ```

--- a/dist/index.js
+++ b/dist/index.js
@@ -5,7 +5,7 @@ module.exports =
 /***/ 244:
 /***/ ((__unused_webpack_module, exports) => {
 
-exports.GRYPE_VERSION = "0.34.4";
+exports.GRYPE_VERSION = "v0.34.4";
 
 
 /***/ }),
@@ -34,7 +34,7 @@ async function downloadGrype(version) {
   // Make sure the tool's executable bit is set
   await exec(`chmod +x ${installPath}`);
 
-  let cmd = `${installPath} -b ${installPath}_grype v${version}`;
+  let cmd = `${installPath} -b ${installPath}_grype ${version}`;
   await exec(cmd);
   let grypePath = `${installPath}_grype/grype`;
 
@@ -238,7 +238,7 @@ if (require.main === require.cache[eval('__filename')]) {
   const entrypoint = core.getInput("run");
   switch (entrypoint) {
     case "download-grype": {
-      const path = installGrype();
+      const path = installGrype(grypeVersion);
       core.setOutput("cmd", path);
       break;
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -239,6 +239,7 @@ if (require.main === require.cache[eval('__filename')]) {
   switch (entrypoint) {
     case "download-grype": {
       const path = installGrype(grypeVersion);
+      core.info(`Downloaded Grype to: ${path}`);
       core.setOutput("cmd", path);
       break;
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -237,7 +237,7 @@ module.exports = {
 if (require.main === require.cache[eval('__filename')]) {
   const entrypoint = core.getInput("run");
   switch (entrypoint) {
-    case "install-grype": {
+    case "download-grype": {
       const path = installGrype();
       core.setOutput("cmd", path);
       break;

--- a/dist/index.js
+++ b/dist/index.js
@@ -238,13 +238,14 @@ if (require.main === require.cache[eval('__filename')]) {
   const entrypoint = core.getInput("run");
   switch (entrypoint) {
     case "download-grype": {
-      const path = installGrype(grypeVersion);
-      core.info(`Downloaded Grype to: ${path}`);
-      core.setOutput("cmd", path);
+      installGrype(grypeVersion).then((path) => {
+        core.info(`Downloaded Grype to: ${path}`);
+        core.setOutput("cmd", path);
+      });
       break;
     }
     default: {
-      run();
+      run().then();
     }
   }
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -2,6 +2,14 @@ module.exports =
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
+/***/ 244:
+/***/ ((__unused_webpack_module, exports) => {
+
+exports.GRYPE_VERSION = "0.34.4";
+
+
+/***/ }),
+
 /***/ 932:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
@@ -10,42 +18,10 @@ const core = __webpack_require__(186);
 const { exec } = __webpack_require__(514);
 const fs = __webpack_require__(747);
 const stream = __webpack_require__(413);
+const { GRYPE_VERSION } = __webpack_require__(244);
 
 const grypeBinary = "grype";
-const grypeVersion = "0.34.1";
-
-// Find all 'content-*.json' files in the directory. dirname should include the full path
-function findContent(searchDir) {
-  let contentFiles = [];
-  let match = /content-.*\.json/;
-  var dirItems = fs.readdirSync(searchDir);
-  if (dirItems) {
-    for (let i = 0; i < dirItems.length; i++) {
-      if (match.test(dirItems[i])) {
-        contentFiles.push(`${searchDir}/${dirItems[i]}`);
-      }
-    }
-  } else {
-    core.debug("no dir content found");
-  }
-
-  core.debug(contentFiles.toString());
-  return contentFiles;
-}
-
-// Load the json content of each file in a list and return them as a list
-function loadContent(files) {
-  let contents = [];
-  if (files) {
-    files.forEach((item) => contents.push(JSON.parse(fs.readFileSync(item))));
-  }
-  return contents;
-}
-
-// Merge the multiple content output types into a single array
-function mergeResults(contentArray) {
-  return contentArray.reduce((merged, n) => merged.concat(n.content), []);
-}
+const grypeVersion = core.getInput("grype-version") || GRYPE_VERSION;
 
 async function downloadGrype(version) {
   let url = `https://raw.githubusercontent.com/anchore/grype/main/install.sh`;
@@ -75,6 +51,7 @@ async function installGrype(version) {
 
   // Add tool to path for this and future actions to use
   core.addPath(grypePath);
+  return `${grypePath}/${grypeBinary}`;
 }
 
 function sourceInput() {
@@ -255,15 +232,20 @@ module.exports = {
   run,
   runScan,
   installGrype,
-  mergeResults,
-  findContent,
-  loadContent,
 };
 
 if (require.main === require.cache[eval('__filename')]) {
-  run().catch((err) => {
-    throw new Error(err);
-  });
+  const entrypoint = core.getInput("run");
+  switch (entrypoint) {
+    case "install-grype": {
+      const path = installGrype();
+      core.setOutput("cmd", path);
+      break;
+    }
+    default: {
+      run();
+    }
+  }
 }
 
 

--- a/download-grype/action.yml
+++ b/download-grype/action.yml
@@ -1,20 +1,20 @@
-name: "Install Grype"
+name: "Download Grype"
 author: "Anchore"
-description: "Install grype"
+description: "Downloads the Grype binary and provides a path to execute it"
 branding:
   color: blue
   icon: check-circle
 inputs:
   grype-version:
-    description: "The version of Grype to install"
+    description: "A specific version of Grype to install"
     required: false
   run:
     description: "Flag to indicate which sub-action to run"
     required: false
-    default: "install-grype"
+    default: "download-grype"
 outputs:
   cmd:
     description: "An absolute path to the Grype executable"
 runs:
   using: "node12"
-  main: "dist/index.js"
+  main: "../dist/index.js"

--- a/grype/action.yml
+++ b/grype/action.yml
@@ -1,0 +1,20 @@
+name: "Install Grype"
+author: "Anchore"
+description: "Install grype"
+branding:
+  color: blue
+  icon: check-circle
+inputs:
+  grype-version:
+    description: "The version of Grype to install"
+    required: false
+  run:
+    description: "Flag to indicate which sub-action to run"
+    required: false
+    default: "install-grype"
+outputs:
+  cmd:
+    description: "An absolute path to the Grype executable"
+runs:
+  using: "node12"
+  main: "dist/index.js"

--- a/index.js
+++ b/index.js
@@ -222,7 +222,7 @@ module.exports = {
 if (require.main === module) {
   const entrypoint = core.getInput("run");
   switch (entrypoint) {
-    case "install-grype": {
+    case "download-grype": {
       const path = installGrype();
       core.setOutput("cmd", path);
       break;

--- a/index.js
+++ b/index.js
@@ -224,6 +224,7 @@ if (require.main === module) {
   switch (entrypoint) {
     case "download-grype": {
       const path = installGrype(grypeVersion);
+      core.info(`Downloaded Grype to: ${path}`);
       core.setOutput("cmd", path);
       break;
     }

--- a/index.js
+++ b/index.js
@@ -223,13 +223,14 @@ if (require.main === module) {
   const entrypoint = core.getInput("run");
   switch (entrypoint) {
     case "download-grype": {
-      const path = installGrype(grypeVersion);
-      core.info(`Downloaded Grype to: ${path}`);
-      core.setOutput("cmd", path);
+      installGrype(grypeVersion).then((path) => {
+        core.info(`Downloaded Grype to: ${path}`);
+        core.setOutput("cmd", path);
+      });
       break;
     }
     default: {
-      run();
+      run().then();
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ async function downloadGrype(version) {
   // Make sure the tool's executable bit is set
   await exec(`chmod +x ${installPath}`);
 
-  let cmd = `${installPath} -b ${installPath}_grype v${version}`;
+  let cmd = `${installPath} -b ${installPath}_grype ${version}`;
   await exec(cmd);
   let grypePath = `${installPath}_grype/grype`;
 
@@ -223,7 +223,7 @@ if (require.main === module) {
   const entrypoint = core.getInput("run");
   switch (entrypoint) {
     case "download-grype": {
-      const path = installGrype();
+      const path = installGrype(grypeVersion);
       core.setOutput("cmd", path);
       break;
     }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
   setupFiles: ["<rootDir>/.jest/setEnvVars.js"],
   verbose: true,
-  testPathIgnorePatterns: ["action.test.js"],
 };

--- a/tests/action.test.js
+++ b/tests/action.test.js
@@ -1,11 +1,39 @@
-const child_process = require('child_process');
-const path = require('path');
-const process = require('process');
+const child_process = require("child_process");
+const os = require("os");
+const path = require("path");
+const process = require("process");
 
-// shows how the runner will run a javascript action with env / stdout protocol
-test('test runs', () => {
-    process.env['INPUT_DEBUG'] = 'true';
-    process.env['INPUT_IMAGE-REFERENCE'] = 'docker.io/alpine:latest';
-    const index_path = path.join(__dirname, '../index.js');
-    console.log(child_process.execSync(`node ${index_path}`, {env: process.env}).toString());
+const actionPath = path.join(__dirname, "../index.js");
+
+// Execute the action, and return any outputs
+function runAction(inputs) {
+  // reverse core.js: const val = process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || '';
+  for (const k in inputs) {
+    process.env[`INPUT_${k}`.toUpperCase()] = inputs[k];
+  }
+  // capture stdout
+  const stdout = child_process
+    .execSync(`node ${actionPath}`, {
+      env: process.env,
+    })
+    .toString("utf8");
+  const outputs = {};
+  // reverse setOutput command calls like:
+  // ::set-output name=cmd::/tmp/actions/cache/grype/0.34.4/x64/grype
+  for (const line of stdout.split(os.EOL)) {
+    const groups = line.match(/::set-output name=(\w+)::(.*)$/);
+    if (groups && groups.length > 2) {
+      outputs[groups[1]] = groups[2];
+    }
+  }
+  return outputs;
+}
+
+describe("sbom-action", () => {
+  it("runs download-grype", () => {
+    const outputs = runAction({
+      run: "download-grype",
+    });
+    expect(outputs.cmd).toBeDefined();
+  });
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,80 +1,113 @@
-const error = require('../dist');
-jest.mock('@actions/core');
-jest.mock('@actions/exec');
-jest.mock('@actions/tool-cache');
+jest.mock("@actions/core");
+jest.mock("@actions/exec");
+jest.mock("@actions/tool-cache");
 
-const _ = require('lodash');
-const core = require('@actions/core');
-const exec = require('@actions/exec');
-const path = require('path');
-const fs = require('fs');
+const core = require("@actions/core");
+const exec = require("@actions/exec");
+const path = require("path");
+const fs = require("fs");
 
-const main = require('..');
-const policyEvaluationFixture = require('./fixtures/policy_evaluation.fixture');
-const contentMergeFixture = require('./fixtures/content-merge.fixture');
+const contentMergeFixture = require("./fixtures/content-merge.fixture");
 
-describe('unit-tests', () => {
-    it('tests merge of outputs into single bill of materials with os-only packages', () => {
-        let merged = main.mergeResults([contentMergeFixture["content-os.json"]]);
-        //console.log("os-only output: " +JSON.stringify(merged));
-        expect(merged.length).toBeGreaterThan(0);
+// Find all 'content-*.json' files in the directory. dirname should include the full path
+function findContent(searchDir) {
+  let contentFiles = [];
+  let match = /content-.*\.json/;
+  var dirItems = fs.readdirSync(searchDir);
+  if (dirItems) {
+    for (let i = 0; i < dirItems.length; i++) {
+      if (match.test(dirItems[i])) {
+        contentFiles.push(`${searchDir}/${dirItems[i]}`);
+      }
+    }
+  } else {
+    core.debug("no dir content found");
+  }
 
+  core.debug(contentFiles.toString());
+  return contentFiles;
+}
+
+// Load the json content of each file in a list and return them as a list
+function loadContent(files) {
+  let contents = [];
+  if (files) {
+    files.forEach((item) => contents.push(JSON.parse(fs.readFileSync(item))));
+  }
+  return contents;
+}
+
+// Merge the multiple content output types into a single array
+function mergeResults(contentArray) {
+  return contentArray.reduce((merged, n) => merged.concat(n.content), []);
+}
+
+describe("unit-tests", () => {
+  it("tests merge of outputs into single bill of materials with os-only packages", () => {
+    let merged = mergeResults([contentMergeFixture["content-os.json"]]);
+    //console.log("os-only output: " +JSON.stringify(merged));
+    expect(merged.length).toBeGreaterThan(0);
+  });
+
+  it("tests merge of outputs into single bill of materials with all packages", () => {
+    let merged = mergeResults([
+      contentMergeFixture["content-os.json"],
+      contentMergeFixture["content-npm.json"],
+      contentMergeFixture["content-gem.json"],
+      contentMergeFixture["content-java.json"],
+      contentMergeFixture["content-python.json"],
+    ]);
+    //console.log("merged output: " +JSON.stringify(merged));
+    expect(merged.length).toBeGreaterThan(0);
+  });
+
+  it("tests finding content files in dir", () => {
+    let testPath = path.join(__dirname, "fixtures");
+
+    const mock = jest.spyOn(fs, "readdirSync");
+    mock.mockImplementation(() => {
+      return Object.keys(contentMergeFixture);
     });
 
-    it('tests merge of outputs into single bill of materials with all packages', () => {
-        let merged = main.mergeResults([contentMergeFixture["content-os.json"], contentMergeFixture["content-npm.json"], contentMergeFixture["content-gem.json"], contentMergeFixture["content-java.json"], contentMergeFixture["content-python.json"]]);
-        //console.log("merged output: " +JSON.stringify(merged));
-        expect(merged.length).toBeGreaterThan(0);
+    let contentFiles = findContent(testPath);
+    expect(contentFiles.length).toEqual(5);
+
+    mock.mockRestore(); // restore fs.readdirSync()
+  });
+
+  it("tests loading content in list", () => {
+    const mock = jest.spyOn(fs, "readFileSync");
+    mock.mockImplementation((i) => {
+      return JSON.stringify(contentMergeFixture[i]);
     });
 
-    it('tests finding content files in dir', () => {
-        let testPath = path.join(__dirname, "fixtures");
+    let contentFiles = loadContent(Object.keys(contentMergeFixture));
+    expect(contentFiles.length).toEqual(5);
 
-        const mock = jest.spyOn(fs, 'readdirSync');
-        mock.mockImplementation(() => {
-            return Object.keys(contentMergeFixture);
-        });
-
-        let contentFiles = main.findContent(testPath);
-        expect(contentFiles.length).toEqual(5);
-
-        mock.mockRestore();  // restore fs.readdirSync()
-    });
-
-    it('tests loading content in list', () => {
-        const mock = jest.spyOn(fs, 'readFileSync');
-        mock.mockImplementation((i) => {
-            return JSON.stringify(contentMergeFixture[i]);
-        });
-
-        let contentFiles = main.loadContent(Object.keys(contentMergeFixture));
-        expect(contentFiles.length).toEqual(5);
-
-        mock.mockRestore();  // restore fs.readFileSync()
-    });
+    mock.mockRestore(); // restore fs.readFileSync()
+  });
 });
 
-describe('functional-tests', () => {
-    beforeEach(() => {
-        exec.exec = jest.fn();
+describe("functional-tests", () => {
+  beforeEach(() => {
+    exec.exec = jest.fn();
 
-        const mockReaddirSync = jest.spyOn(fs, 'readdirSync');
-        mockReaddirSync.mockImplementation(() => {
-            return Object.keys(contentMergeFixture);
-        });
-
-        const mockWriteFileSync = jest.spyOn(fs, 'writeFileSync');
-        mockWriteFileSync.mockImplementation((i) => jest.fn());
-
-        core.getInput = jest
-            .fn()
-            .mockReturnValueOnce('localbuild/testimage:12345')  // image-reference
-            .mockReturnValueOnce('./Dockerfile')                // dockerfile-path
-            .mockReturnValueOnce('true')                        // debug
-            .mockReturnValueOnce('true')                        // fail-build
-            .mockReturnValueOnce('false')                       // acs-report
-            .mockReturnValueOnce('Medium')                      // sev-cut-off
-            .mockReturnValueOnce(null)                          // version	
+    const mockReaddirSync = jest.spyOn(fs, "readdirSync");
+    mockReaddirSync.mockImplementation(() => {
+      return Object.keys(contentMergeFixture);
     });
 
+    const mockWriteFileSync = jest.spyOn(fs, "writeFileSync");
+    mockWriteFileSync.mockImplementation(() => jest.fn());
+
+    core.getInput = jest
+      .fn()
+      .mockReturnValueOnce("localbuild/testimage:12345") // image-reference
+      .mockReturnValueOnce("./Dockerfile") // dockerfile-path
+      .mockReturnValueOnce("true") // debug
+      .mockReturnValueOnce("true") // fail-build
+      .mockReturnValueOnce("false") // acs-report
+      .mockReturnValueOnce("Medium") // sev-cut-off
+      .mockReturnValueOnce(null); // version
+  });
 });


### PR DESCRIPTION
This PR adds a sub-action to download grype, along with some misc. code clean up that was discovered while working on this:
* functions included in the compiled action code which were only being used by tests
* split grype version to a separate file in preparation for adding an auto-updating job in a follow-on PR

An example run is: https://github.com/kzantow-anchore/scan-action-test/runs/5739124385?check_suite_focus=true#step:5:12

With an execution of the Grype binary: https://github.com/kzantow-anchore/scan-action-test/runs/5739124385?check_suite_focus=true#step:7:1