### PR TITLE
Add auto-PR creator to keep pinned Grype up to date

### DIFF
--- a/.github/workflows/update-grype-release.yml
+++ b/.github/workflows/update-grype-release.yml
@@ -1,0 +1,38 @@
+name: PR for latest Grype release
+on:
+  schedule:
+    # 7:04 UTC (2:04 am EST)
+    - cron: "4 7 * * *"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  upgrade-grype:
+    runs-on: ubuntu-latest
+    if: github.repository == 'anchore/scan-action'
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          LATEST_VERSION=$(curl "https://api.github.com/repos/anchore/grype/releases/latest" 2>/dev/null | jq -r '.tag_name')
+          echo "export const VERSION = \"$LATEST_VERSION\";" > GrypeVersion.ts
+          # install husky hooks and dependencies:
+          npm install
+          # export the version for use with create-pull-request:
+          echo "::set-output name=LATEST_VERSION::$LATEST_VERSION"
+        id: latest-version
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: peter-evans/create-pull-request@v4
+        with:
+          signoff: true
+          delete-branch: true
+          branch: auto/latest
+          labels: dependencies
+          commit-message: "Update Grype to ${{ steps.latest-version.outputs.LATEST_VERSION }}"
+          title: "Update Grype to ${{ steps.latest-version.outputs.LATEST_VERSION }}"
+          body: "Update Grype to ${{ steps.latest-version.outputs.LATEST_VERSION }}"
+          token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
To help keep the pinned version of Grype up to date, we want a workflow to handle this for us so we know if tests start failing or we can just update with no problem. This PR adds a nightly workflow that checks to see if a new Grype has been released and creates or updates a PR with the corresponding update, including tests.

This fixes #147 