### PR TITLE
Update grype release check secret names

### DIFF
--- a/.github/workflows/update-grype-release.yml
+++ b/.github/workflows/update-grype-release.yml
@@ -24,8 +24,8 @@ jobs:
       - uses: tibdex/github-app-token@v1
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.TOKEN_APP_ID }}
+          private_key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
       - uses: peter-evans/create-pull-request@v4
         with:
           signoff: true


### PR DESCRIPTION
Ths PR updates the secret names due to moving to organization secrets for the automatic PR when grype is released.