### PR TITLE
Correct Grype auto-updater

### DIFF
--- a/.github/workflows/update-grype-release.yml
+++ b/.github/workflows/update-grype-release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: |
           LATEST_VERSION=$(curl "https://api.github.com/repos/anchore/grype/releases/latest" 2>/dev/null | jq -r '.tag_name')
-          echo "export const VERSION = \"$LATEST_VERSION\";" > GrypeVersion.ts
+          echo "export const VERSION = \"$LATEST_VERSION\";" > GrypeVersion.js
           # install husky hooks and dependencies:
           npm install
           # export the version for use with create-pull-request:


### PR DESCRIPTION
The auto-updater job was incorrectly referencing a `.ts` instead of a `.js` file.