### PR TITLE
Explicitly run `npm run build` for auto-update PR

### DIFF
--- a/.github/workflows/update-grype-release.yml
+++ b/.github/workflows/update-grype-release.yml
@@ -18,6 +18,7 @@ jobs:
           echo "exports.GRYPE_VERSION = \"$LATEST_VERSION\";" > GrypeVersion.js
           # install husky hooks and dependencies:
           npm install
+          npm run build
           # export the version for use with create-pull-request:
           echo "::set-output name=LATEST_VERSION::$LATEST_VERSION"
         id: latest-version


### PR DESCRIPTION
For some unknown reason the `npm install` for the automatic grype PR does not appear to be installing the husky hooks; we can workaround this by explicitly running `npm run build`.