### PR TITLE
Add author to the release drafter template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -10,7 +10,7 @@ categories:
       - "fix"
       - "bugfix"
       - "bug"
-change-template: "- $TITLE (#$NUMBER)"
+change-template: "- $TITLE (#$NUMBER) [$AUTHOR](https://github.com/$AUTHOR)"
 version-resolver:
   major:
     labels:


### PR DESCRIPTION
Syft and Grype have an author in the release notes automatically, we should add that to the release drafter template here, too.

See release-drafter docs: https://github.com/marketplace/actions/release-drafter#change-template-variables