### PR TITLE
Update CodeQL Action in example to v2

### DIFF
--- a/.github/workflows/sarifdemo.yml
+++ b/.github/workflows/sarifdemo.yml
@@ -25,7 +25,7 @@ jobs:
     # Commented out to prevent incorrect SARIF uploads for this action
     # TODO: add functional tests that validate this
     # - name: Upload SARIF
-    #   uses: github/codeql-action/upload-sarif@v1
+    #   uses: github/codeql-action/upload-sarif@v2
     #   with:
     #     sarif_file: ${{ steps.scan.outputs.sarif }}
 
@@ -50,6 +50,6 @@ jobs:
     # Commented out to prevent incorrect SARIF uploads for this action
     # TODO: add functional tests that validate this
     # - name: Upload SARIF
-    #   uses: github/codeql-action/upload-sarif@v1
+    #   uses: github/codeql-action/upload-sarif@v2
     #   with:
     #     sarif_file: ${{ steps.scan.outputs.sarif }}

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ jobs:
           image: "localbuild/testimage:latest"
           acs-report-enable: true
       - name: upload Anchore scan SARIF report
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
 ```


### PR DESCRIPTION
As is with v1, you get the following warning on an Actions run:

> `CodeQL Action v1 will be deprecated on December 7th, 2022.
> Please upgrade to v2.
> For more information, see https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/`

Signed-off-by: Steven Maude <git@stevenmaude.co.uk>