### PR TITLE
Allow input parameter `output-format` and output `report` to be used

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: "Set to false to avoid failing based on severity-cutoff. Default is to fail when severity-cutoff is reached (or surpassed)"
     required: false
     default: "true"
+  output-format:
+    description: 'Set the output parameter after successful action execution. Valid choices are "json" and "sarif".'
+    required: false
+    default: "sarif"
   acs-report-enable:
     description: "Generate a SARIF report and set the `sarif` output parameter after successful action execution.  This report is compatible with GitHub Automated Code Scanning (ACS), as the artifact to upload for display as a Code Scanning Alert report."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,8 @@ inputs:
 outputs:
   sarif:
     description: "Path to a SARIF report file for the image"
+  report:
+    description: "Path to a JSON report file for the image"
 runs:
   using: "node16"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -103,12 +103,14 @@ async function run() {
     const source = sourceInput();
     const failBuild = core.getInput("fail-build") || "true";
     const acsReportEnable = core.getInput("acs-report-enable") || "true";
+    const outputFormat = core.getInput("output-format") || "sarif";
     const severityCutoff = core.getInput("severity-cutoff") || "medium";
     const out = await runScan({
       source,
       failBuild,
       acsReportEnable,
       severityCutoff,
+      outputFormat,
     });
     Object.keys(out).map((key) => {
       core.setOutput(key, out[key]);
@@ -118,7 +120,13 @@ async function run() {
   }
 }
 
-async function runScan({ source, failBuild, acsReportEnable, severityCutoff }) {
+async function runScan({
+  source,
+  failBuild,
+  acsReportEnable,
+  severityCutoff,
+  outputFormat,
+}) {
   const out = {};
 
   const env = {
@@ -139,6 +147,7 @@ async function runScan({ source, failBuild, acsReportEnable, severityCutoff }) {
   }
 
   const SEVERITY_LIST = ["negligible", "low", "medium", "high", "critical"];
+  const FORMAT_LIST = ["sarif", "json"];
   let cmdArgs = [];
 
   if (core.isDebug()) {
@@ -152,7 +161,7 @@ async function runScan({ source, failBuild, acsReportEnable, severityCutoff }) {
   if (acsReportEnable) {
     cmdArgs.push("-o", "sarif");
   } else {
-    cmdArgs.push("-o", "json");
+    cmdArgs.push("-o", outputFormat);
   }
 
   if (
@@ -166,6 +175,17 @@ async function runScan({ source, failBuild, acsReportEnable, severityCutoff }) {
       `Invalid severity-cutoff value is set to ${severityCutoff} - please ensure you are choosing either negligible, low, medium, high, or critical`
     );
   }
+  if (
+    !FORMAT_LIST.some(
+      (item) =>
+        typeof outputFormat.toLowerCase() === "string" &&
+        item === outputFormat.toLowerCase()
+    )
+  ) {
+    throw new Error(
+      `Invalid output-format value is set to ${outputFormat} - please ensure you are choosing either json or sarif`
+    );
+  }
 
   core.debug(`Installing grype version ${grypeVersion}`);
   await installGrype(grypeVersion);
@@ -174,6 +194,7 @@ async function runScan({ source, failBuild, acsReportEnable, severityCutoff }) {
   core.debug("Fail Build: " + failBuild);
   core.debug("Severity Cutoff: " + severityCutoff);
   core.debug("ACS Enable: " + acsReportEnable);
+  core.debug("Output Format: " + outputFormat);
 
   core.debug("Creating options for GRYPE analyzer");
 
@@ -225,6 +246,10 @@ async function runScan({ source, failBuild, acsReportEnable, severityCutoff }) {
     const SARIF_FILE = "./results.sarif";
     fs.writeFileSync(SARIF_FILE, cmdOutput);
     out.sarif = SARIF_FILE;
+  } else {
+    const REPORT_FILE = "./results.report";
+    fs.writeFileSync(REPORT_FILE, cmdOutput);
+    out.report = REPORT_FILE;
   }
 
   if (failBuild === true && exitCode > 0) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -158,6 +158,12 @@ async function runScan({
 
   acsReportEnable = acsReportEnable.toLowerCase() === "true";
 
+  if (outputFormat !== "sarif" && acsReportEnable) {
+    throw new Error(
+      `Invalid output-format selected. If acs-report-enabled is true (which is the default if it is omitted), the output-format parameter must be sarif or must be omitted`
+    );
+  }
+
   if (acsReportEnable) {
     cmdArgs.push("-o", "sarif");
   } else {

--- a/index.js
+++ b/index.js
@@ -143,6 +143,12 @@ async function runScan({
 
   acsReportEnable = acsReportEnable.toLowerCase() === "true";
 
+  if (outputFormat !== "sarif" && acsReportEnable) {
+    throw new Error(
+      `Invalid output-format selected. If acs-report-enabled is true (which is the default if it is omitted), the output-format parameter must be sarif or must be omitted`
+    );
+  }
+
   if (acsReportEnable) {
     cmdArgs.push("-o", "sarif");
   } else {

--- a/index.js
+++ b/index.js
@@ -88,12 +88,14 @@ async function run() {
     const source = sourceInput();
     const failBuild = core.getInput("fail-build") || "true";
     const acsReportEnable = core.getInput("acs-report-enable") || "true";
+    const outputFormat = core.getInput("output-format") || "sarif";
     const severityCutoff = core.getInput("severity-cutoff") || "medium";
     const out = await runScan({
       source,
       failBuild,
       acsReportEnable,
       severityCutoff,
+      outputFormat,
     });
     Object.keys(out).map((key) => {
       core.setOutput(key, out[key]);
@@ -103,7 +105,13 @@ async function run() {
   }
 }
 
-async function runScan({ source, failBuild, acsReportEnable, severityCutoff }) {
+async function runScan({
+  source,
+  failBuild,
+  acsReportEnable,
+  severityCutoff,
+  outputFormat,
+}) {
   const out = {};
 
   const env = {
@@ -124,6 +132,7 @@ async function runScan({ source, failBuild, acsReportEnable, severityCutoff }) {
   }
 
   const SEVERITY_LIST = ["negligible", "low", "medium", "high", "critical"];
+  const FORMAT_LIST = ["sarif", "json"];
   let cmdArgs = [];
 
   if (core.isDebug()) {
@@ -137,7 +146,7 @@ async function runScan({ source, failBuild, acsReportEnable, severityCutoff }) {
   if (acsReportEnable) {
     cmdArgs.push("-o", "sarif");
   } else {
-    cmdArgs.push("-o", "json");
+    cmdArgs.push("-o", outputFormat);
   }
 
   if (
@@ -151,6 +160,17 @@ async function runScan({ source, failBuild, acsReportEnable, severityCutoff }) {
       `Invalid severity-cutoff value is set to ${severityCutoff} - please ensure you are choosing either negligible, low, medium, high, or critical`
     );
   }
+  if (
+    !FORMAT_LIST.some(
+      (item) =>
+        typeof outputFormat.toLowerCase() === "string" &&
+        item === outputFormat.toLowerCase()
+    )
+  ) {
+    throw new Error(
+      `Invalid output-format value is set to ${outputFormat} - please ensure you are choosing either json or sarif`
+    );
+  }
 
   core.debug(`Installing grype version ${grypeVersion}`);
   await installGrype(grypeVersion);
@@ -159,6 +179,7 @@ async function runScan({ source, failBuild, acsReportEnable, severityCutoff }) {
   core.debug("Fail Build: " + failBuild);
   core.debug("Severity Cutoff: " + severityCutoff);
   core.debug("ACS Enable: " + acsReportEnable);
+  core.debug("Output Format: " + outputFormat);
 
   core.debug("Creating options for GRYPE analyzer");
 
@@ -210,6 +231,10 @@ async function runScan({ source, failBuild, acsReportEnable, severityCutoff }) {
     const SARIF_FILE = "./results.sarif";
     fs.writeFileSync(SARIF_FILE, cmdOutput);
     out.sarif = SARIF_FILE;
+  } else {
+    const REPORT_FILE = "./results.report";
+    fs.writeFileSync(REPORT_FILE, cmdOutput);
+    out.report = REPORT_FILE;
   }
 
   if (failBuild === true && exitCode > 0) {

--- a/tests/grype_command.test.js
+++ b/tests/grype_command.test.js
@@ -29,6 +29,7 @@ describe("Grype command", () => {
       debug: "false",
       failBuild: "false",
       acsReportEnable: "true",
+      outputFormat: "sarif",
       severityCutoff: "high",
       version: "0.6.0",
     });
@@ -40,6 +41,7 @@ describe("Grype command", () => {
       source: "asdf",
       failBuild: "false",
       acsReportEnable: "false",
+      outputFormat: "json",
       severityCutoff: "low",
       version: "0.6.0",
     });

--- a/tests/sarif_output.test.js
+++ b/tests/sarif_output.test.js
@@ -18,6 +18,7 @@ const testSource = async (source, vulnerabilities) => {
     debug: "false",
     failBuild: "false",
     acsReportEnable: "true",
+    outputFormat: "sarif",
     severityCutoff: "medium",
   });
 


### PR DESCRIPTION
This fixes issue #186.

The PR #184 missed out on updating the `action.yml` to describe the new input parameter and output field for the action.

Secondly, in that PR only the `./dist/index.js` file was updated with the new feature, but the source file `./index.js` was left untouched. Any subsequent run and commit of `npm run build` would have erased the changes.
I've moved the new code into `./index.js` and regenerated `./dist/index.js`. That also looks to have picked up a few changes due to library updates that had not been integrated into the `dist` output yet.
Finally I've updated a few tests to make them work properly with the new feature.