### PR TITLE
Update output-format and acs-report-enable disconnect

### DIFF
--- a/.github/workflows/sarifdemo.yml
+++ b/.github/workflows/sarifdemo.yml
@@ -15,7 +15,6 @@ jobs:
         with:
           image: "debian:8"
           debug: true
-          acs-report-enable: true
           fail-build: false
           #severity-cutoff: "Medium"
 
@@ -41,7 +40,6 @@ jobs:
         with:
           path: "tests/fixtures/npm-project"
           debug: true
-          acs-report-enable: true
           fail-build: false
           #severity-cutoff: "Medium"
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ The simplest workflow for scanning a `localbuild/testimage` container:
     push: false
     load: true
 
- - name: Scan image
-   uses: anchore/scan-action@v3
-   with:
-     image: "localbuild/testimage:latest"
+- name: Scan image
+  uses: anchore/scan-action@v3
+  with:
+    image: "localbuild/testimage:latest"
 ```
 
 ## Directory scanning
@@ -116,26 +116,25 @@ Optionally, change the `fail-build` field to `false` to avoid failing the build 
 
 ### Action Inputs
 
-The inputs `image`, `path`, and `sbom` are mutually exclusive to specify the source to scan;inputs `output-format` and`acs-report-enable` are mutually exclusive to specify the report format;all the other keys are optional. These are all the available keys to configure this action, along with the defaults:
+The inputs `image`, `path`, and `sbom` are mutually exclusive to specify the source to scan; all the other keys are optional. These are all the available keys to configure this action, along with the defaults:
 
-| Input Name          | Description                                                                                                                                                                                                                                                                                                    | Default Value |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `image`             | The image to scan                                                                                                                                                                                                                                                                                              | N/A           |
-| `path`              | The file path to scan                                                                                                                                                                                                                                                                                          | N/A           |
-| `sbom`              | The SBOM to scan                                                                                                                                                                                                                                                                                               | N/A           |
-| `registry-username` | The registry username to use when authenticating to an external registry                                                                                                                                                                                                                                       |               |
-| `registry-password` | The registry password to use when authenticating to an external registry                                                                                                                                                                                                                                       |               |
-| `fail-build`        | Fail the build if a vulnerability is found with a higher severity. That severity defaults to `"medium"` and can be set with `severity-cutoff`.                                                                                                                                                                 | `true`        |
-| `output-format`     | Set the output parameter after successful action execution. Valid choices are "json" and "sarif"                                                                                                                                                                                                               | `sarif`       |
-| `acs-report-enable` | Generate a SARIF report and set the `sarif` output parameter (Override the output-format) after successful action execution. This report is compatible with GitHub Automated Code Scanning (ACS), as the artifact to upload for display as a Code Scanning Alert report.                                       | `true`        |
-| `severity-cutoff`   | With ACS reporting enabled, optionally specify the minimum vulnerability severity to trigger an "error" level ACS result. Valid choices are "negligible", "low", "medium", "high" and "critical". Any vulnerability with a severity less than this value will lead to a "warning" result. Default is "medium". | `"medium"`    |
+| Input Name          | Description                                                                                                                                                                                                                                                      | Default Value |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `image`             | The image to scan                                                                                                                                                                                                                                                | N/A           |
+| `path`              | The file path to scan                                                                                                                                                                                                                                            | N/A           |
+| `sbom`              | The SBOM to scan                                                                                                                                                                                                                                                 | N/A           |
+| `registry-username` | The registry username to use when authenticating to an external registry                                                                                                                                                                                         |               |
+| `registry-password` | The registry password to use when authenticating to an external registry                                                                                                                                                                                         |               |
+| `fail-build`        | Fail the build if a vulnerability is found with a higher severity. That severity defaults to `"medium"` and can be set with `severity-cutoff`.                                                                                                                   | `true`        |
+| `output-format`     | Set the output parameter after successful action execution. Valid choices are "json" and "sarif"                                                                                                                                                                 | `sarif`       |
+| `severity-cutoff`   | Optionally specify the minimum vulnerability severity to trigger a failure. Valid choices are "negligible", "low", "medium", "high" and "critical". Any vulnerability with a severity less than this value will lead to a "warning" result. Default is "medium". | `"medium"`    |
 
 ### Action Outputs
 
-| Output Name | Description                   | Type   |
-| ----------- | ----------------------------- | ------ |
-| `sarif`     | Path to the SARIF report file | string |
-| `report`    | Path to the report file       | string |
+| Output Name | Description                                                  | Type   |
+| ----------- | ------------------------------------------------------------ | ------ |
+| `sarif`     | Path to the SARIF report file, if `output-format` is `sarif` | string |
+| `json`      | Path to the report file , if `output-format` is `json`       | string |
 
 ### Example Workflows
 
@@ -157,7 +156,7 @@ jobs:
           fail-build: true
 ```
 
-Same example as above, but with Automated Code Scanning (ACS) feature enabled - with this example, the action will generate a SARIF report, which can be uploaded and then displayed as a Code Scanning Report in the GitHub UI.
+Same example as above, but with SARIF output format - as is the default, the action will generate a SARIF report, which can be uploaded and then displayed as a Code Scanning Report in the GitHub UI.
 
 > :bulb: Code Scanning is a Github service that is currently in Beta. [Follow the instructions on how to enable this service for your project](https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/enabling-code-scanning-for-a-repository).
 
@@ -175,7 +174,6 @@ jobs:
         id: scan
         with:
           image: "localbuild/testimage:latest"
-          acs-report-enable: true
       - name: upload Anchore scan SARIF report
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/action.yml
+++ b/action.yml
@@ -21,10 +21,6 @@ inputs:
     description: 'Set the output parameter after successful action execution. Valid choices are "json" and "sarif".'
     required: false
     default: "sarif"
-  acs-report-enable:
-    description: "Generate a SARIF report and set the `sarif` output parameter after successful action execution.  This report is compatible with GitHub Automated Code Scanning (ACS), as the artifact to upload for display as a Code Scanning Alert report."
-    required: false
-    default: "true"
   severity-cutoff:
     description: 'Optionally specify the minimum vulnerability severity to trigger an "error" level ACS result.  Valid choices are "negligible", "low", "medium", "high" and "critical".  Any vulnerability with a severity less than this value will lead to a "warning" result.  Default is "medium".'
     required: false
@@ -32,7 +28,7 @@ inputs:
 outputs:
   sarif:
     description: "Path to a SARIF report file for the image"
-  report:
+  json:
     description: "Path to a JSON report file for the image"
 runs:
   using: "node16"

--- a/index.js
+++ b/index.js
@@ -87,13 +87,11 @@ async function run() {
     // a check must happen to ensure one is selected at least, and then return it
     const source = sourceInput();
     const failBuild = core.getInput("fail-build") || "true";
-    const acsReportEnable = core.getInput("acs-report-enable") || "true";
     const outputFormat = core.getInput("output-format") || "sarif";
     const severityCutoff = core.getInput("severity-cutoff") || "medium";
     const out = await runScan({
       source,
       failBuild,
-      acsReportEnable,
       severityCutoff,
       outputFormat,
     });
@@ -105,13 +103,7 @@ async function run() {
   }
 }
 
-async function runScan({
-  source,
-  failBuild,
-  acsReportEnable,
-  severityCutoff,
-  outputFormat,
-}) {
+async function runScan({ source, failBuild, severityCutoff, outputFormat }) {
   const out = {};
 
   const env = {
@@ -141,19 +133,7 @@ async function runScan({
 
   failBuild = failBuild.toLowerCase() === "true";
 
-  acsReportEnable = acsReportEnable.toLowerCase() === "true";
-
-  if (outputFormat !== "sarif" && acsReportEnable) {
-    throw new Error(
-      `Invalid output-format selected. If acs-report-enabled is true (which is the default if it is omitted), the output-format parameter must be sarif or must be omitted`
-    );
-  }
-
-  if (acsReportEnable) {
-    cmdArgs.push("-o", "sarif");
-  } else {
-    cmdArgs.push("-o", outputFormat);
-  }
+  cmdArgs.push("-o", outputFormat);
 
   if (
     !SEVERITY_LIST.some(
@@ -184,7 +164,6 @@ async function runScan({
   core.debug("Source: " + source);
   core.debug("Fail Build: " + failBuild);
   core.debug("Severity Cutoff: " + severityCutoff);
-  core.debug("ACS Enable: " + acsReportEnable);
   core.debug("Output Format: " + outputFormat);
 
   core.debug("Creating options for GRYPE analyzer");
@@ -233,12 +212,12 @@ async function runScan({
     core.debug(cmdOutput);
   }
 
-  if (acsReportEnable) {
+  if (outputFormat === "sarif") {
     const SARIF_FILE = "./results.sarif";
     fs.writeFileSync(SARIF_FILE, cmdOutput);
     out.sarif = SARIF_FILE;
   } else {
-    const REPORT_FILE = "./results.report";
+    const REPORT_FILE = "./results.json";
     fs.writeFileSync(REPORT_FILE, cmdOutput);
     out.report = REPORT_FILE;
   }

--- a/tests/action_args.test.js
+++ b/tests/action_args.test.js
@@ -9,7 +9,7 @@ describe("Github action args", () => {
       image: "",
       path: "tests/fixtures/npm-project",
       "fail-build": "true",
-      "acs-report-enable": "false",
+      "output-format": "json",
       "severity-cutoff": "medium",
     };
     const spyInput = jest.spyOn(core, "getInput").mockImplementation((name) => {
@@ -44,7 +44,7 @@ describe("Github action args", () => {
       image: "",
       path: "tests/fixtures/npm-project",
       "fail-build": "true",
-      "acs-report-enable": "true",
+      "output-format": "sarif",
       "severity-cutoff": "medium",
     };
     const spyInput = jest.spyOn(core, "getInput").mockImplementation((name) => {

--- a/tests/grype_command.test.js
+++ b/tests/grype_command.test.js
@@ -28,7 +28,6 @@ describe("Grype command", () => {
       source: "dir:.",
       debug: "false",
       failBuild: "false",
-      acsReportEnable: "true",
       outputFormat: "sarif",
       severityCutoff: "high",
       version: "0.6.0",
@@ -40,7 +39,6 @@ describe("Grype command", () => {
     let cmd = await mockExec({
       source: "asdf",
       failBuild: "false",
-      acsReportEnable: "false",
       outputFormat: "json",
       severityCutoff: "low",
       version: "0.6.0",

--- a/tests/sarif_output.test.js
+++ b/tests/sarif_output.test.js
@@ -17,7 +17,6 @@ const testSource = async (source, vulnerabilities) => {
     source,
     debug: "false",
     failBuild: "false",
-    acsReportEnable: "true",
     outputFormat: "sarif",
     severityCutoff: "medium",
   });


### PR DESCRIPTION
This PR is a follow up to #187 which renames the json output file to more closely align to the `output-format` option of `json` or `sarif`, as well as removing the `acs-report-enable` flag, which is no longer necessary.

NOTE: this is not really a breaking change, as the defaults of `output-format=sarif` and `acs-report-enable=true` will result in the same behavior.