### PR TITLE
Include process environment into grype execution

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14,7 +14,7 @@ exports.GRYPE_VERSION = "v0.52.0";
 
 const cache = __nccwpck_require__(7784);
 const core = __nccwpck_require__(2186);
-const { exec } = __nccwpck_require__(1514);
+const exec = __nccwpck_require__(1514);
 const fs = __nccwpck_require__(7147);
 const stream = __nccwpck_require__(2781);
 const { GRYPE_VERSION } = __nccwpck_require__(6244);
@@ -31,10 +31,10 @@ async function downloadGrype(version) {
   // Download the installer, and run
   const installPath = await cache.downloadTool(url);
   // Make sure the tool's executable bit is set
-  await exec(`chmod +x ${installPath}`);
+  await exec.exec(`chmod +x ${installPath}`);
 
   let cmd = `${installPath} -b ${installPath}_grype ${version}`;
-  await exec(cmd);
+  await exec.exec(cmd);
   let grypePath = `${installPath}_grype/grype`;
 
   // Cache the downloaded file
@@ -121,6 +121,7 @@ async function runScan({ source, failBuild, severityCutoff, outputFormat }) {
   const out = {};
 
   const env = {
+    ...process.env,
     GRYPE_CHECK_FOR_APP_UPDATE: "false",
   };
 
@@ -203,7 +204,7 @@ async function runScan({ source, failBuild, severityCutoff, outputFormat }) {
   const exitCode = await core.group(`${cmd} output...`, async () => {
     core.info(`Executing: ${cmd} ` + cmdArgs.join(" "));
 
-    return exec(cmd, cmdArgs, {
+    return exec.exec(cmd, cmdArgs, {
       env,
       ignoreReturnCode: true,
       outStream,

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const cache = require("@actions/tool-cache");
 const core = require("@actions/core");
-const { exec } = require("@actions/exec");
+const exec = require("@actions/exec");
 const fs = require("fs");
 const stream = require("stream");
 const { GRYPE_VERSION } = require("./GrypeVersion");
@@ -17,10 +17,10 @@ async function downloadGrype(version) {
   // Download the installer, and run
   const installPath = await cache.downloadTool(url);
   // Make sure the tool's executable bit is set
-  await exec(`chmod +x ${installPath}`);
+  await exec.exec(`chmod +x ${installPath}`);
 
   let cmd = `${installPath} -b ${installPath}_grype ${version}`;
-  await exec(cmd);
+  await exec.exec(cmd);
   let grypePath = `${installPath}_grype/grype`;
 
   // Cache the downloaded file
@@ -107,6 +107,7 @@ async function runScan({ source, failBuild, severityCutoff, outputFormat }) {
   const out = {};
 
   const env = {
+    ...process.env,
     GRYPE_CHECK_FOR_APP_UPDATE: "false",
   };
 
@@ -189,7 +190,7 @@ async function runScan({ source, failBuild, severityCutoff, outputFormat }) {
   const exitCode = await core.group(`${cmd} output...`, async () => {
     core.info(`Executing: ${cmd} ` + cmdArgs.join(" "));
 
-    return exec(cmd, cmdArgs, {
+    return exec.exec(cmd, cmdArgs, {
       env,
       ignoreReturnCode: true,
       outStream,

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   },
   "scripts": {
     "lint": "eslint index.js",
-    "test": "eslint index.js && npm run download-pinned-grype-db && GRYPE_DB_AUTO_UPDATE=false GRYPE_DB_CACHE_DIR=./grype-db jest",
-    "test:update-snapshots": "eslint index.js && npm run download-pinned-grype-db && GRYPE_DB_AUTO_UPDATE=false GRYPE_DB_CACHE_DIR=./grype-db jest --updateSnapshot",
-    "download-pinned-grype-db": "mkdir -p grype-db/3 && curl -sL https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v3_2022-03-16T08:14:11Z.tar.gz | tar zxf - -C grype-db/3",
+    "test": "eslint index.js && npm run download-pinned-grype-db && GRYPE_DB_AUTO_UPDATE=false GRYPE_DB_CACHE_DIR=./grype-db GRYPE_DB_VALIDATE_AGE=false jest",
+    "test:update-snapshots": "eslint index.js && npm run download-pinned-grype-db && GRYPE_DB_AUTO_UPDATE=false GRYPE_DB_CACHE_DIR=./grype-db GRYPE_DB_VALIDATE_AGE=false jest --updateSnapshot",
+    "download-pinned-grype-db": "mkdir -p grype-db/5 && curl -sL https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v5_2022-10-17T08:14:57Z_b50a86ce07d268101316.tar.gz | tar zxf - -C grype-db/5",
     "build": "ncc build ./index.js",
     "precommit": "pretty-quick --staged && npm run build && git add dist/",
     "prepare": "husky install",


### PR DESCRIPTION
Adds the current process environment variables to the grype process. Useful for proxy variables.

Might fix https://github.com/anchore/scan-action/issues/197 