### PR TITLE
chore: update actions-tagger

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -9,7 +9,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: Actions-R-Us/actions-tagger@v2
-        env:
-          GITHUB_TOKEN: "${{ github.token }}"
         with:
           publish_latest_tag: true


### PR DESCRIPTION
Updates `actions-tagger` action to remove `GITHUB_TOKEN` environment variable.