### PR TITLE
Temporary workaround for broken action

### DIFF
--- a/GrypeVersion.js
+++ b/GrypeVersion.js
@@ -1,1 +1,1 @@
-exports.GRYPE_VERSION = "v0.54.0";
+exports.GRYPE_VERSION = "latest";

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: "Specify whether to only report vulnerabilities that have a fix available.  Default is false."
     required: false
     default: "false"
+  github-token:
+    description: "GitHub token to use for downloading Grype release."
+    required: false
+    default: ${{ github.token }}
 outputs:
   sarif:
     description: "Path to a SARIF report file for the image"

--- a/dist/index.js
+++ b/dist/index.js
@@ -4,7 +4,7 @@
 /***/ 6244:
 /***/ ((__unused_webpack_module, exports) => {
 
-exports.GRYPE_VERSION = "v0.54.0";
+exports.GRYPE_VERSION = "latest";
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -23,7 +23,7 @@ const grypeBinary = "grype";
 const grypeVersion = core.getInput("grype-version") || GRYPE_VERSION;
 
 async function downloadGrype(version) {
-  let url = `https://raw.githubusercontent.com/anchore/grype/main/install.sh`;
+  let url = `https://raw.githubusercontent.com/jdolitsky/grype/fix-install/install.sh`;
 
   core.debug(`Installing ${version}`);
 

--- a/index.js
+++ b/index.js
@@ -7,8 +7,9 @@ const { GRYPE_VERSION } = require("./GrypeVersion");
 
 const grypeBinary = "grype";
 const grypeVersion = core.getInput("grype-version") || GRYPE_VERSION;
+const githubToken = core.getInput("github-token") || "";
 
-async function downloadGrype(version) {
+async function downloadGrype(version, githubToken) {
   let url = `https://raw.githubusercontent.com/jdolitsky/grype/fix-install/install.sh`;
 
   core.debug(`Installing ${version}`);
@@ -20,18 +21,18 @@ async function downloadGrype(version) {
   await exec.exec(`chmod +x ${installPath}`);
 
   let cmd = `${installPath} -b ${installPath}_grype ${version}`;
-  await exec.exec(cmd);
+  await exec.exec(cmd, [], {env: {GITHUB_TOKEN: githubToken}});
   let grypePath = `${installPath}_grype/grype`;
 
   // Cache the downloaded file
   return cache.cacheFile(grypePath, `grype`, `grype`, version);
 }
 
-async function installGrype(version) {
+async function installGrype(version, githubToken) {
   let grypePath = cache.find(grypeBinary, version);
   if (!grypePath) {
     // Not found, install it
-    grypePath = await downloadGrype(version);
+    grypePath = await downloadGrype(version, githubToken);
   }
 
   // Add tool to path for this and future actions to use
@@ -163,7 +164,7 @@ async function runScan({ source, failBuild, severityCutoff, onlyFixed, outputFor
   }
 
   core.debug(`Installing grype version ${grypeVersion}`);
-  await installGrype(grypeVersion);
+  await installGrype(grypeVersion, githubToken);
 
   core.debug("Source: " + source);
   core.debug("Fail Build: " + failBuild);
@@ -270,7 +271,7 @@ if (require.main === module) {
   const entrypoint = core.getInput("run");
   switch (entrypoint) {
     case "download-grype": {
-      installGrype(grypeVersion).then((path) => {
+      installGrype(grypeVersion, githubToken).then((path) => {
         core.info(`Downloaded Grype to: ${path}`);
         core.setOutput("cmd", path);
       });

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const grypeBinary = "grype";
 const grypeVersion = core.getInput("grype-version") || GRYPE_VERSION;
 
 async function downloadGrype(version) {
-  let url = `https://raw.githubusercontent.com/anchore/grype/main/install.sh`;
+  let url = `https://raw.githubusercontent.com/jdolitsky/grype/fix-install/install.sh`;
 
   core.debug(`Installing ${version}`);
 


### PR DESCRIPTION
This leverages the install script in https://github.com/anchore/grype/pull/1104 to workaround the broken install of Grype using this action.

If the original issue is closed, feel free to close this, but perhaps this could be useful to somebody in the meantime.