### PR TITLE
add action input for --add-cpes-if-none flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The inputs `image`, `path`, and `sbom` are mutually exclusive to specify the sou
 | `output-format`     | Set the output parameter after successful action execution. Valid choices are `json`, `sarif`, and `table`, where `table` output will print to the console instead of generating a file.                                                                         | `sarif`       |
 | `severity-cutoff`   | Optionally specify the minimum vulnerability severity to trigger a failure. Valid choices are "negligible", "low", "medium", "high" and "critical". Any vulnerability with a severity less than this value will lead to a "warning" result. Default is "medium". | `medium`      |
 | `only-fixed`        | Specify whether to only report vulnerabilities that have a fix available.                                                                                                                                                                                        | `false`       |
+| `add-cpes-if-none`  | Specify whether to autogenerate missing CPEs.                                                                                                                                                                                                                    | `false`       |
 
 ### Action Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: "Specify whether to only report vulnerabilities that have a fix available.  Default is false."
     required: false
     default: "false"
+  add-cpes-if-none:
+    description: "Specify whether to autogenerate missing CPEs.  Default is false."
+    required: false
+    default: "false"
 outputs:
   sarif:
     description: "Path to a SARIF report file for the image"

--- a/dist/index.js
+++ b/dist/index.js
@@ -104,12 +104,14 @@ async function run() {
     const outputFormat = core.getInput("output-format") || "sarif";
     const severityCutoff = core.getInput("severity-cutoff") || "medium";
     const onlyFixed = core.getInput("only-fixed") || "false";
+    const addCpesIfNone = core.getInput("add-cpes-if-none") || "false";
     const out = await runScan({
       source,
       failBuild,
       severityCutoff,
       onlyFixed,
       outputFormat,
+      addCpesIfNone,
     });
     Object.keys(out).map((key) => {
       core.setOutput(key, out[key]);
@@ -119,7 +121,7 @@ async function run() {
   }
 }
 
-async function runScan({ source, failBuild, severityCutoff, onlyFixed, outputFormat }) {
+async function runScan({ source, failBuild, severityCutoff, onlyFixed, outputFormat, addCpesIfNone }) {
   const out = {};
 
   const env = {
@@ -150,6 +152,7 @@ async function runScan({ source, failBuild, severityCutoff, onlyFixed, outputFor
 
   failBuild = failBuild.toLowerCase() === "true";
   onlyFixed = onlyFixed.toLowerCase() === "true";
+  addCpesIfNone = addCpesIfNone.toLowerCase() === "true";
 
   cmdArgs.push("-o", outputFormat);
 
@@ -183,6 +186,7 @@ async function runScan({ source, failBuild, severityCutoff, onlyFixed, outputFor
   core.debug("Fail Build: " + failBuild);
   core.debug("Severity Cutoff: " + severityCutoff);
   core.debug("Only Fixed: " + onlyFixed);
+  core.debug("Add Missing CPEs: " + addCpesIfNone);
   core.debug("Output Format: " + outputFormat);
 
   core.debug("Creating options for GRYPE analyzer");
@@ -196,6 +200,9 @@ async function runScan({ source, failBuild, severityCutoff, onlyFixed, outputFor
   }
   if (onlyFixed === true) {
     cmdArgs.push("--only-fixed");
+  }
+  if (addCpesIfNone === true) {
+    cmdArgs.push("--add-cpes-if-none");
   }
   cmdArgs.push(source);
 

--- a/index.js
+++ b/index.js
@@ -90,12 +90,14 @@ async function run() {
     const outputFormat = core.getInput("output-format") || "sarif";
     const severityCutoff = core.getInput("severity-cutoff") || "medium";
     const onlyFixed = core.getInput("only-fixed") || "false";
+    const addCpesIfNone = core.getInput("add-cpes-if-none") || "false";
     const out = await runScan({
       source,
       failBuild,
       severityCutoff,
       onlyFixed,
       outputFormat,
+      addCpesIfNone,
     });
     Object.keys(out).map((key) => {
       core.setOutput(key, out[key]);
@@ -105,7 +107,7 @@ async function run() {
   }
 }
 
-async function runScan({ source, failBuild, severityCutoff, onlyFixed, outputFormat }) {
+async function runScan({ source, failBuild, severityCutoff, onlyFixed, outputFormat, addCpesIfNone }) {
   const out = {};
 
   const env = {
@@ -136,6 +138,7 @@ async function runScan({ source, failBuild, severityCutoff, onlyFixed, outputFor
 
   failBuild = failBuild.toLowerCase() === "true";
   onlyFixed = onlyFixed.toLowerCase() === "true";
+  addCpesIfNone = addCpesIfNone.toLowerCase() === "true";
 
   cmdArgs.push("-o", outputFormat);
 
@@ -169,6 +172,7 @@ async function runScan({ source, failBuild, severityCutoff, onlyFixed, outputFor
   core.debug("Fail Build: " + failBuild);
   core.debug("Severity Cutoff: " + severityCutoff);
   core.debug("Only Fixed: " + onlyFixed);
+  core.debug("Add Missing CPEs: " + addCpesIfNone);
   core.debug("Output Format: " + outputFormat);
 
   core.debug("Creating options for GRYPE analyzer");
@@ -182,6 +186,9 @@ async function runScan({ source, failBuild, severityCutoff, onlyFixed, outputFor
   }
   if (onlyFixed === true) {
     cmdArgs.push("--only-fixed");
+  }
+  if (addCpesIfNone === true) {
+    cmdArgs.push("--add-cpes-if-none");
   }
   cmdArgs.push(source);
 

--- a/tests/action_args.test.js
+++ b/tests/action_args.test.js
@@ -12,6 +12,7 @@ describe("Github action args", () => {
       "fail-build": "true",
       "output-format": "json",
       "severity-cutoff": "medium",
+      "add-cpes-if-none": "true",
     };
     const spyInput = jest.spyOn(core, "getInput").mockImplementation((name) => {
       try {
@@ -47,6 +48,7 @@ describe("Github action args", () => {
       "fail-build": "true",
       "output-format": "sarif",
       "severity-cutoff": "medium",
+      "add-cpes-if-none": "true",
     };
     const spyInput = jest.spyOn(core, "getInput").mockImplementation((name) => {
       try {
@@ -81,6 +83,7 @@ describe("Github action args", () => {
       "fail-build": "true",
       "output-format": "table",
       "severity-cutoff": "medium",
+      "add-cpes-if-none": "true",
     };
     const spyInput = jest.spyOn(core, "getInput").mockImplementation((name) => {
       try {

--- a/tests/grype_command.test.js
+++ b/tests/grype_command.test.js
@@ -32,6 +32,7 @@ describe("Grype command", () => {
       severityCutoff: "high",
       version: "0.6.0",
       onlyFixed: "false",
+      addCpesIfNone: "false",
     });
     expect(cmd).toBe("grype -o sarif --fail-on high dir:.");
   });
@@ -44,6 +45,7 @@ describe("Grype command", () => {
       severityCutoff: "low",
       version: "0.6.0",
       onlyFixed: "false",
+      addCpesIfNone: "false",
     });
     expect(cmd).toBe("grype -o json --fail-on low asdf");
   });

--- a/tests/grype_command.test.js
+++ b/tests/grype_command.test.js
@@ -49,4 +49,17 @@ describe("Grype command", () => {
     });
     expect(cmd).toBe("grype -o json --fail-on low asdf");
   });
+
+  it("adds missing CPEs if requested", async () => {
+    let cmd = await mockExec({
+      source: "asdf",
+      failBuild: "false",
+      outputFormat: "json",
+      severityCutoff: "low",
+      version: "0.6.0",
+      onlyFixed: "false",
+      addCpesIfNone: "true",
+    });
+    expect(cmd).toBe("grype -o json --fail-on low --add-cpes-if-none asdf");
+  });
 });

--- a/tests/sarif_output.test.js
+++ b/tests/sarif_output.test.js
@@ -20,6 +20,7 @@ const testSource = async (source, vulnerabilities) => {
     outputFormat: "sarif",
     severityCutoff: "medium",
     onlyFixed: "false",
+    addCpesIfNone: "false",
   });
 
   // expect to get sarif output


### PR DESCRIPTION
Fixes #215 by adding another action input that toggles whether the `--add-cpes-if-none` flag is added to the grype command arguments.

There are some local test failures but these seems to be caused by a missing OCI registry on localhost:5000 which I did not have. I've tested this change just now in https://github.com/metio/devcontainers/commit/bbb47b0aca4ff5fdd4bdec5d64d1649e071bc866 and can see the correct results in an action run, e.g. at https://github.com/metio/devcontainers/actions/runs/4445318515/jobs/7804325686 (job name is "Scan Image with Grype")