### PR TITLE
Set json output

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -251,7 +251,7 @@ async function runScan({ source, failBuild, severityCutoff, onlyFixed, outputFor
     case "json": {
       const REPORT_FILE = "./results.json";
       fs.writeFileSync(REPORT_FILE, cmdOutput);
-      out.report = REPORT_FILE;
+      out.json = REPORT_FILE;
       break;
     }
     default: // e.g. table

--- a/index.js
+++ b/index.js
@@ -237,7 +237,7 @@ async function runScan({ source, failBuild, severityCutoff, onlyFixed, outputFor
     case "json": {
       const REPORT_FILE = "./results.json";
       fs.writeFileSync(REPORT_FILE, cmdOutput);
-      out.report = REPORT_FILE;
+      out.json = REPORT_FILE;
       break;
     }
     default: // e.g. table

--- a/tests/action_args.test.js
+++ b/tests/action_args.test.js
@@ -5,7 +5,7 @@ const exec = require("@actions/exec");
 jest.setTimeout(30000);
 
 describe("Github action args", () => {
-  it("runs without sarif report", async () => {
+  it("runs with json report", async () => {
     const inputs = {
       image: "",
       path: "tests/fixtures/npm-project",
@@ -36,6 +36,7 @@ describe("Github action args", () => {
     });
 
     expect(outputs["sarif"]).toBeFalsy();
+    expect(outputs["json"]).toBe("./results.json");
 
     spyInput.mockRestore();
     spyOutput.mockRestore();


### PR DESCRIPTION
Set the `json` Action output instead of `report` to match what the [documentation](https://github.com/anchore/scan-action/blob/main/README.md?plain=1#L139) describes.