### PR TITLE
chore: add manual trigger to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: "Tests"
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build: # make sure build/ci work properly and there is no faked build ncc built scripts


### PR DESCRIPTION
I've seen some flakiness / surprises with this workflow, and so would like to be able to trigger it directly on `main` to see if it's misbehaving there as well.