### PR TITLE
chore: address test flakes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: "Tests"
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build: # make sure build/ci work properly and there is no faked build ncc built scripts

--- a/tests/action_args.test.js
+++ b/tests/action_args.test.js
@@ -2,7 +2,7 @@ const { run } = require("../index");
 const core = require("@actions/core");
 const exec = require("@actions/exec");
 
-jest.setTimeout(60000);
+jest.setTimeout(90000);
 
 describe("Github action args", () => {
   it("runs with json report", async () => {

--- a/tests/action_args.test.js
+++ b/tests/action_args.test.js
@@ -2,7 +2,7 @@ const { run } = require("../index");
 const core = require("@actions/core");
 const exec = require("@actions/exec");
 
-jest.setTimeout(90000);
+jest.setTimeout(90000); // 90 seconds; tests were timing out in CI. https://github.com/anchore/scan-action/pull/249
 
 describe("Github action args", () => {
   it("runs with json report", async () => {

--- a/tests/action_args.test.js
+++ b/tests/action_args.test.js
@@ -2,7 +2,7 @@ const { run } = require("../index");
 const core = require("@actions/core");
 const exec = require("@actions/exec");
 
-jest.setTimeout(30000);
+jest.setTimeout(60000);
 
 describe("Github action args", () => {
   it("runs with json report", async () => {

--- a/tests/grype_command.test.js
+++ b/tests/grype_command.test.js
@@ -2,7 +2,7 @@ const githubActionsExec = require("@actions/exec");
 const githubActionsToolCache = require("@actions/tool-cache");
 const core = require("@actions/core");
 
-jest.setTimeout(90000);
+jest.setTimeout(90000); // 90 seconds; tests were timing out in CI. https://github.com/anchore/scan-action/pull/249
 
 jest.spyOn(githubActionsToolCache, "find").mockImplementation(() => {
   return "grype";

--- a/tests/grype_command.test.js
+++ b/tests/grype_command.test.js
@@ -2,7 +2,7 @@ const githubActionsExec = require("@actions/exec");
 const githubActionsToolCache = require("@actions/tool-cache");
 const core = require("@actions/core");
 
-jest.setTimeout(30000);
+jest.setTimeout(60000);
 
 jest.spyOn(githubActionsToolCache, "find").mockImplementation(() => {
   return "grype";

--- a/tests/grype_command.test.js
+++ b/tests/grype_command.test.js
@@ -2,7 +2,7 @@ const githubActionsExec = require("@actions/exec");
 const githubActionsToolCache = require("@actions/tool-cache");
 const core = require("@actions/core");
 
-jest.setTimeout(60000);
+jest.setTimeout(90000);
 
 jest.spyOn(githubActionsToolCache, "find").mockImplementation(() => {
   return "grype";

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -2,6 +2,12 @@ jest.mock("@actions/core");
 jest.mock("@actions/exec");
 jest.mock("@actions/tool-cache");
 
+beforeAll(async () => {
+  const { grypeVersion } = require("../GrypeVersion");
+  const { installGrype } = require("../index");
+  await installGrype(grypeVersion);
+});
+
 const core = require("@actions/core");
 const path = require("path");
 const fs = require("fs");

--- a/tests/sarif_output.test.js
+++ b/tests/sarif_output.test.js
@@ -3,7 +3,7 @@ require("@microsoft/jest-sarif"); // for sarif validation
 const fs = require("fs");
 const { runScan } = require("../index");
 
-jest.setTimeout(90000);
+jest.setTimeout(90000); // 90 seconds; tests were timing out in CI. https://github.com/anchore/scan-action/pull/249
 
 const testSource = async (source, vulnerabilities) => {
   if (fs.existsSync("./vulnerabilities.json")) {

--- a/tests/sarif_output.test.js
+++ b/tests/sarif_output.test.js
@@ -3,7 +3,7 @@ require("@microsoft/jest-sarif"); // for sarif validation
 const fs = require("fs");
 const { runScan } = require("../index");
 
-jest.setTimeout(60000);
+jest.setTimeout(90000);
 
 const testSource = async (source, vulnerabilities) => {
   if (fs.existsSync("./vulnerabilities.json")) {

--- a/tests/sarif_output.test.js
+++ b/tests/sarif_output.test.js
@@ -3,7 +3,7 @@ require("@microsoft/jest-sarif"); // for sarif validation
 const fs = require("fs");
 const { runScan } = require("../index");
 
-jest.setTimeout(30000);
+jest.setTimeout(60000);
 
 const testSource = async (source, vulnerabilities) => {
   if (fs.existsSync("./vulnerabilities.json")) {


### PR DESCRIPTION
There seem to be a few things happening:

1. We sometimes hit jest timeouts. 
2. We sometimes hit `spawn ETXTBSY` from Node, which means that we tried to exec a file that is also open for writing. I think this is a race condition where one test is running grype while another is installing it.
3. We sometimes have an error like: couldn't exec `grype`: is the filename correct and the file marked as executable? (Like this: https://github.com/anchore/scan-action/actions/runs/6931060595/job/18851984035#step:8:144). I think this is also a race WRT to installing grype.

Therefore:
- bump jest timeout from 30s to 90s. Downloading grype and grype DB can take some time, so this seems reasonable
- Install grype in a `beforeAll`, so that when the individual tests run grype, it's already there, so hopefully no one will race to install it.
