### PR TITLE
Add support for the `--vex` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The inputs `image`, `path`, and `sbom` are mutually exclusive to specify the sou
 | `only-fixed`        | Specify whether to only report vulnerabilities that have a fix available.                                                                                                                                                                                        | `false`       |
 | `add-cpes-if-none`  | Specify whether to autogenerate missing CPEs.                                                                                                                                                                                                                    | `false`       |
 | `by-cve`            | Specify whether to orient results by CVE rather than GHSA.                                                                                                                                                                                                       | `false`       |
+| `vex`               | Specify a list of VEX documents to consider when producing scanning results.                                                                                                                                                                                     | `false`       |
 
 ### Action Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,9 @@ inputs:
   grype-version:
     description: "A specific version of Grype to install"
     required: false
+  vex:
+    description: "Specify a list of VEX documents to consider when producing scanning results."
+    required: false
 outputs:
   sarif:
     description: "Path to a SARIF report file for the image"

--- a/dist/index.js
+++ b/dist/index.js
@@ -106,6 +106,7 @@ async function run() {
     const onlyFixed = core.getInput("only-fixed") || "false";
     const addCpesIfNone = core.getInput("add-cpes-if-none") || "false";
     const byCve = core.getInput("by-cve") || "false";
+    const vex = core.getInput("vex") || "";
     const out = await runScan({
       source,
       failBuild,
@@ -114,6 +115,7 @@ async function run() {
       outputFormat,
       addCpesIfNone,
       byCve,
+      vex,
     });
     Object.keys(out).map((key) => {
       core.setOutput(key, out[key]);
@@ -131,6 +133,7 @@ async function runScan({
   outputFormat,
   addCpesIfNone,
   byCve,
+  vex,
 }) {
   const out = {};
 
@@ -218,6 +221,10 @@ async function runScan({
   }
   if (byCve === true) {
     cmdArgs.push("--by-cve");
+  }
+  if (vex) {
+    cmdArgs.push("--vex");
+    cmdArgs.push(vex);
   }
   cmdArgs.push(source);
 

--- a/index.js
+++ b/index.js
@@ -92,6 +92,7 @@ async function run() {
     const onlyFixed = core.getInput("only-fixed") || "false";
     const addCpesIfNone = core.getInput("add-cpes-if-none") || "false";
     const byCve = core.getInput("by-cve") || "false";
+    const vex = core.getInput("vex") || "";
     const out = await runScan({
       source,
       failBuild,
@@ -100,6 +101,7 @@ async function run() {
       outputFormat,
       addCpesIfNone,
       byCve,
+      vex,
     });
     Object.keys(out).map((key) => {
       core.setOutput(key, out[key]);
@@ -117,6 +119,7 @@ async function runScan({
   outputFormat,
   addCpesIfNone,
   byCve,
+  vex,
 }) {
   const out = {};
 
@@ -204,6 +207,10 @@ async function runScan({
   }
   if (byCve === true) {
     cmdArgs.push("--by-cve");
+  }
+  if (vex) {
+    cmdArgs.push("--vex");
+    cmdArgs.push(vex);
   }
   cmdArgs.push(source);
 

--- a/tests/action_args.test.js
+++ b/tests/action_args.test.js
@@ -13,6 +13,7 @@ describe("Github action args", () => {
       "output-format": "json",
       "severity-cutoff": "medium",
       "add-cpes-if-none": "true",
+      "vex": "test.vex",
     };
     const spyInput = jest.spyOn(core, "getInput").mockImplementation((name) => {
       try {

--- a/tests/grype_command.test.js
+++ b/tests/grype_command.test.js
@@ -69,4 +69,21 @@ describe("Grype command", () => {
       `${cmdPrefix} -o json --fail-on low --add-cpes-if-none asdf`
     );
   });
+
+  it("adds VEX processing if requested", async () => {
+    let cmd = await mockExec({
+      source: "asdf",
+      failBuild: "false",
+      outputFormat: "json",
+      severityCutoff: "low",
+      version: "0.6.0",
+      onlyFixed: "false",
+      addCpesIfNone: "true",
+      byCve: "false",
+      vex: "test.vex",
+    });
+    expect(cmd).toBe(
+      `${cmdPrefix} -o json --fail-on low --add-cpes-if-none --vex test.vex asdf`
+    );
+  });
 });


### PR DESCRIPTION
Functionality to implement VEX support in the GitHub action as described in https://github.com/anchore/scan-action/issues/253 

I have added a test and run the existing tests - all tests pass.

I haven't modified all tests to take this argument because I didn't see the benefit, but if there are specific tests beyond the ones that I've added/changed that would help, let me know and I will add them.