### PR TITLE
Bump of Node to v20 on download-grype action. Increased timeout for tests.

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Draft release notes
-        uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5.25.0
+        uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/download-grype/action.yml
+++ b/download-grype/action.yml
@@ -16,5 +16,5 @@ outputs:
   cmd:
     description: "An absolute path to the Grype executable"
 runs:
-  using: "node16"
+  using: "node20"
   main: "../dist/index.js"

--- a/tests/grype_command.test.js
+++ b/tests/grype_command.test.js
@@ -2,7 +2,7 @@ const githubActionsExec = require("@actions/exec");
 const githubActionsToolCache = require("@actions/tool-cache");
 const core = require("@actions/core");
 
-jest.setTimeout(90000); // 90 seconds; tests were timing out in CI. https://github.com/anchore/scan-action/pull/249
+jest.setTimeout(120000); // 120 seconds; tests were timing out in CI. https://github.com/anchore/scan-action/pull/249
 
 jest.spyOn(githubActionsToolCache, "find").mockImplementation(() => {
   return "grype";
@@ -66,7 +66,7 @@ describe("Grype command", () => {
       byCve: "false",
     });
     expect(cmd).toBe(
-      `${cmdPrefix} -o json --fail-on low --add-cpes-if-none asdf`
+      `${cmdPrefix} -o json --fail-on low --add-cpes-if-none asdf`,
     );
   });
 
@@ -83,7 +83,7 @@ describe("Grype command", () => {
       vex: "test.vex",
     });
     expect(cmd).toBe(
-      `${cmdPrefix} -o json --fail-on low --add-cpes-if-none --vex test.vex asdf`
+      `${cmdPrefix} -o json --fail-on low --add-cpes-if-none --vex test.vex asdf`,
     );
   });
 });


### PR DESCRIPTION
- bump of Node to v20 for "child" download-grype action
part of https://github.com/anchore/scan-action/issues/276
- increased timeout https://github.com/anchore/scan-action/actions/runs/8215199273/job/22468413564#step:8:132