### PR TITLE
fix: download Grype directly on Windows

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30,7 +30,10 @@ async function downloadGrypeWindowsWorkaround(version) {
   const url = `https://github.com/anchore/grype/releases/download/${version}/grype_${versionNoV}_windows_amd64.zip`;
   core.info(`Downloading grype from ${url}`);
   const zipPath = await cache.downloadTool(url);
+  core.debug(`Zip saved to ${zipPath}`);
   const toolDir = await cache.extractZip(zipPath);
+  core.debug(`Zip extracted to ${toolDir}`);
+  core.debug(`Grype path is ${path.join(toolDir, grypeBinary)}`);
   return path.join(toolDir, grypeBinary);
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -16,6 +16,7 @@ const cache = __nccwpck_require__(7784);
 const core = __nccwpck_require__(2186);
 const exec = __nccwpck_require__(1514);
 const fs = __nccwpck_require__(7147);
+const path = __nccwpck_require__(1017);
 const stream = __nccwpck_require__(2781);
 const { GRYPE_VERSION } = __nccwpck_require__(6244);
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -46,7 +46,10 @@ async function downloadGrype(version) {
 
   core.debug(`Installing ${version}`);
   if (isWindows()) {
-    return downloadGrypeWindowsWorkaround(version);
+    // caller expects directory to add to path and join with executable name
+    const exeFilePath = await downloadGrypeWindowsWorkaround(version);
+    core.debug(`Grype saved to ${exeFilePath}`);
+    return path.dirname(exeFilePath);
   }
 
   // TODO: when grype starts supporting unreleased versions, support it here

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const cache = require("@actions/tool-cache");
 const core = require("@actions/core");
 const exec = require("@actions/exec");
 const fs = require("fs");
+const path = require("path");
 const stream = require("stream");
 const { GRYPE_VERSION } = require("./GrypeVersion");
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,10 @@ async function downloadGrypeWindowsWorkaround(version) {
   const url = `https://github.com/anchore/grype/releases/download/${version}/grype_${versionNoV}_windows_amd64.zip`;
   core.info(`Downloading grype from ${url}`);
   const zipPath = await cache.downloadTool(url);
+  core.debug(`Zip saved to ${zipPath}`);
   const toolDir = await cache.extractZip(zipPath);
+  core.debug(`Zip extracted to ${toolDir}`);
+  core.debug(`Grype path is ${path.join(toolDir, grypeBinary)}`);
   return path.join(toolDir, grypeBinary);
 }
 

--- a/index.js
+++ b/index.js
@@ -32,7 +32,10 @@ async function downloadGrype(version) {
 
   core.debug(`Installing ${version}`);
   if (isWindows()) {
-    return downloadGrypeWindowsWorkaround(version);
+    // caller expects directory to add to path and join with executable name
+    const exeFilePath = await downloadGrypeWindowsWorkaround(version);
+    core.debug(`Grype saved to ${exeFilePath}`);
+    return path.dirname(exeFilePath);
   }
 
   // TODO: when grype starts supporting unreleased versions, support it here

--- a/index.js
+++ b/index.js
@@ -9,10 +9,27 @@ const exeSuffix = process.platform == "win32" ? ".exe" : "";
 const grypeBinary = "grype" + exeSuffix;
 const grypeVersion = core.getInput("grype-version") || GRYPE_VERSION;
 
+async function downloadGrypeWindowsWorkaround(version) {
+  const versionNoV = version.replace(/^v/, "");
+  // example URL: https://github.com/anchore/grype/releases/download/v0.79.2/grype_0.79.2_windows_amd64.zip
+  const url = `https://github.com/anchore/grype/releases/download/${version}/grype_${versionNoV}_windows_amd64.zip`;
+  core.info(`Downloading grype from ${url}`);
+  const zipPath = await cache.downloadTool(url);
+  const toolDir = await cache.extractZip(zipPath);
+  return path.join(toolDir, grypeBinary);
+}
+
+function isWindows() {
+  return process.platform == "win32";
+}
+
 async function downloadGrype(version) {
   let url = `https://raw.githubusercontent.com/anchore/grype/main/install.sh`;
 
   core.debug(`Installing ${version}`);
+  if (isWindows()) {
+    return downloadGrypeWindowsWorkaround(version);
+  }
 
   // TODO: when grype starts supporting unreleased versions, support it here
   // Download the installer, and run


### PR DESCRIPTION
GitHub Actions windows runners currently have a version of curl that doesn't work with the install.sh script in the grype repo. At least temporarily, just download and extract the grype executable directly from the GH release page.