### PR TITLE
Update slack to discourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # GitHub Action for Vulnerability Scanning
 
+**:zap: _Find threats in files or containers at lightning speed_ :zap:**
+
 [![Test Status][test-img]][test]
 [![GitHub release](https://img.shields.io/github/release/anchore/scan-action.svg)](https://github.com/anchore/scan-action/releases/latest)
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/anchore/scan-action/blob/main/LICENSE)
-[![Slack Invite](https://img.shields.io/badge/Slack-Join-blue?logo=slack)](https://anchore.com/slack)
+[![License: Apache-2.0](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/anchore/scan-action/blob/main/LICENSE)
+[![Join our Discourse](https://img.shields.io/badge/Discourse-Join-blue?logo=discourse)](https://anchore.com/discourse)
 
-:zap: _Find threats in files or containers at lightning speed_ :zap:
 
 This is a GitHub Action for invoking the [Grype](https://github.com/anchore/grype) scanner and returning the vulnerabilities found,
 and optionally fail if a vulnerability is found with a configurable severity level.
@@ -235,7 +236,7 @@ For contributing, see [Contributing](CONTRIBUTING.md).
 
 For documentation on Grype itself, including other output capabilities, see the [grype project](https://github.com/anchore/grype)
 
-Connect with the community directly on [slack](https://anchore.com/slack).
+Connect with the community directly on [Discourse](https://anchore.com/discourse).
 
 [test]: https://github.com/anchore/scan-action
 [test-img]: https://github.com/anchore/scan-action/workflows/Tests/badge.svg

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Test Status][test-img]][test]
 [![GitHub release](https://img.shields.io/github/release/anchore/scan-action.svg)](https://github.com/anchore/scan-action/releases/latest)
-[![License: Apache-2.0](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/anchore/scan-action/blob/main/LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/anchore/scan-action/blob/main/LICENSE)
 [![Join our Discourse](https://img.shields.io/badge/Discourse-Join-blue?logo=discourse)](https://anchore.com/discourse)
 
 


### PR DESCRIPTION
This updates the links to the community Slack to Discourse links, and fixes the incorrect license badge name.