### PR TITLE
Adjust upload-sarif version to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ jobs:
         with:
           image: "localbuild/testimage:latest"
       - name: upload Anchore scan SARIF report
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
 ```


### PR DESCRIPTION
Currently with v2, you get the following warning on an Action run:

`Warning: CodeQL Action v2 will be deprecated on December 5th, 2024. Please update all occurrences of the CodeQL Action in your workflow files to v3. For more information, see https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/ 
`

>Users of the above-mentioned platforms should update their CodeQL workflow file(s) to refer to the new v3 version of the CodeQL Action.


Signed-off-by: Christof Renner [christof.renner@zeroday.network](mailto:christof.renner@zeroday.network)