### PR TITLE
chore: exclude dev-deps from release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -26,6 +26,11 @@ version-resolver:
 exclude-labels:
   - 'changelog-ignore'
 
+autolabeler:
+  - label: 'changelog-ignore'
+    title:
+      - '/chore[(]\s*deps-dev\s*[)]\s*[:].*/i'
+
 template: |
   ## New in scan-action v$RESOLVED_VERSION
 


### PR DESCRIPTION
This PR adjusts the release drafter to exclude dev dependencies.