### PR TITLE
Missing perms for cql sarif upld

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Permissions key is required for CodeQL SARIF Upload, per the docs:
+    # https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Build the Container image


### PR DESCRIPTION
Fix issue with missing permissions directive in example workflow
Per the docs here:
https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#example-workflow-for-sarif-files-generated-outside-of-a-repository

The permissions section is required for the SARIF upload sub-action to
 work correctly.