### PR TITLE
chore: bump Grype version to 0.99.1

### DIFF
--- a/GrypeVersion.js
+++ b/GrypeVersion.js
@@ -1,1 +1,1 @@
-exports.GRYPE_VERSION = "v0.98.0";
+exports.GRYPE_VERSION = "v0.99.1";

--- a/dist/index.js
+++ b/dist/index.js
@@ -4,7 +4,7 @@
 /***/ 4739:
 /***/ ((__unused_webpack_module, exports) => {
 
-exports.GRYPE_VERSION = "v0.98.0";
+exports.GRYPE_VERSION = "v0.99.1";
 
 
 /***/ }),

--- a/tests/action.test.js
+++ b/tests/action.test.js
@@ -199,6 +199,6 @@ describe("Github action", () => {
       vex: "missing-file",
     });
 
-    expect(stdout).toContain("no such file or directory");
+    expect(stdout).toContain('VEX document "missing-file" not found');
   });
 });


### PR DESCRIPTION
I noticed #507 was failing due to the changes made in https://github.com/anchore/grype/pull/1826 to what the output from the vex processor is when the provided vex file doesn't exist, so I figured I'd fix the test and bump the Grype version.