### PR TITLE
Tighten workflow permissions, dependabot config, and add CodeQL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: /
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
@@ -11,7 +13,7 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,61 @@
+# CodeQL scans for security vulnerabilities and coding errors across all
+# languages in this repo. Results appear in the "Security" tab under
+# "Code scanning alerts" and are enforced by branch protection rules.
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  # Weekly scheduled scan catches newly disclosed vulnerabilities in
+  # existing code, not just changes introduced by PRs.
+  schedule:
+    - cron: '38 11 * * 3'
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload SARIF results to the "Security" tab.
+      security-events: write
+      # Required to fetch internal or private CodeQL packs.
+      packages: read
+      # Only required for workflows in private repositories.
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # GitHub Actions workflow linting - no build needed.
+          - language: actions
+            build-mode: none
+
+          # javascript-typescript uses none build mode.
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          # The category tag lets GitHub associate SARIF results with the
+          # correct language when branch protection checks for required
+          # code scanning results.
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   update_release_draft:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,8 +1,9 @@
 name: Re-tag releases
 
 on:
-  release:
-    types: [published, edited]
+  push:
+    tags:
+      - "v*"
 
 permissions: {}
 

--- a/.github/workflows/validate-github-actions.yaml
+++ b/.github/workflows/validate-github-actions.yaml
@@ -10,8 +10,7 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   zizmor:


### PR DESCRIPTION
Brings several workflow hygiene items into compliance: restricts top-level permissions, tightens trigger scope, updates dependabot schedule, and adds a CodeQL scan.

Changes:
- set workflow-level `permissions: {}` in `release-drafter.yml` and `validate-github-actions.yaml`; per-job blocks already carry what each job needs
- restrict `tag-release.yml` to fire on tag-push (`v*`) only, so `contents: write` is not active on arbitrary release events
- switch dependabot `github-actions` and `npm` schedules from daily to weekly; add `/.github/actions/*` to the `github-actions` directories
- add `codeql.yaml` with `javascript-typescript` and `actions` matrix, pinned SHAs, weekly schedule