### PR TITLE
Keep update-grype-release target name

### DIFF
--- a/.make/main.go
+++ b/.make/main.go
@@ -41,7 +41,7 @@ func main() {
 		// who can then commit the diff and open a PR by hand. Requires `gh`
 		// to be authenticated (gh auth login).
 		Task{
-			Name:        "update-grype",
+			Name:        "update-grype-release",
 			Description: "bump GrypeVersion.js to the latest grype release and rebuild dist/",
 			Run: func() {
 				version := strings.TrimSpace(Run(`gh release view --json name -q '.name' -R anchore/grype`))

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,4 +10,4 @@ make release
 
 ## Updating Grype
 
-`make update-grype` repins `GrypeVersion.js` and rebuilds `dist/` — review the diff and open a PR. Requires `gh` auth.
+`make update-grype-release` repins `GrypeVersion.js` and rebuilds `dist/` — review the diff and open a PR. Requires `gh` auth.


### PR DESCRIPTION
This restores the original target name used before the go-make refactor