### PR TITLE
fix: declare registry-username and registry-password inputs in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: 'The SBOM file to scan. This option is mutually exclusive with "path" and "image".'
     required: false
   registry-username:
-    description: "The registry username to use when authenticating to an external registry"
+    description: 'Registry username for authenticating to a container registry. Must be specified together with "registry-password".'
     required: false
   registry-password:
     description: "The registry password to use when authenticating to an external registry"

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,12 @@ inputs:
   sbom:
     description: 'The SBOM file to scan. This option is mutually exclusive with "path" and "image".'
     required: false
+  registry-username:
+    description: "The registry username to use when authenticating to an external registry"
+    required: false
+  registry-password:
+    description: "The registry password to use when authenticating to an external registry"
+    required: false
   fail-build:
     description: "Set to false to avoid failing based on severity-cutoff. Default is to fail when severity-cutoff is reached (or surpassed)"
     required: false


### PR DESCRIPTION
fix: declare registry-username and registry-password inputs in action.yml

`registry-username` and `registry-password` were added to the README and implemented in `action.js` (via `core.getInput()`) in #158, but were never declared in `action.yml`.

This means the inputs are functionally supported but undocumented in the action metadata — no IDE autocomplete, no validation, and the inputs table in README references inputs that don't appear in `action.yml`.

This PR adds the missing declarations to `action.yml` to match the existing implementation.