### PR TITLE
Add pr-comment option to post scan results on pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/anchore/scan-action/blob/main/LICENSE)
 [![Join our Discourse](https://img.shields.io/badge/Discourse-Join-blue?logo=discourse)](https://anchore.com/discourse)
 
-
 This is a GitHub Action for invoking the [Grype](https://github.com/anchore/grype) scanner and returning the vulnerabilities found,
 and optionally fail if a vulnerability is found with a configurable severity level.
 
@@ -118,12 +117,23 @@ Optionally, change the `fail-build` field to `false` to avoid failing the build 
     fail-build: false
 ```
 
+To post the scan results as a comment on the pull request (a single comment is updated across runs), set `pr-comment: true` and pass a `github-token` with the `pull-requests: write` permission. This requires `output-format: sarif` (the default):
+
+```yaml
+- name: Scan image
+  uses: anchore/scan-action@v7
+  with:
+    image: "localbuild/testimage:latest"
+    pr-comment: true
+    github-token: ${{ github.token }}
+```
+
 ### Action Inputs
 
 The inputs `image`, `path`, and `sbom` are mutually exclusive to specify the source to scan; all the other keys are optional. These are all the available keys to configure this action, along with the defaults:
 
 | Input Name          | Description                                                                                                                                                                                                                                                      | Default Value |
-|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
 | `image`             | The image to scan                                                                                                                                                                                                                                                | N/A           |
 | `path`              | The file path to scan                                                                                                                                                                                                                                            | N/A           |
 | `sbom`              | The SBOM to scan                                                                                                                                                                                                                                                 | N/A           |
@@ -140,11 +150,13 @@ The inputs `image`, `path`, and `sbom` are mutually exclusive to specify the sou
 | `cache-db`          | Cache the Grype DB in GitHub action cache and restore before checking for updates                                                                                                                                                                                | `false`       |
 | `grype-version`     | An optional Grype version to download, defaults to the pinned version in [GrypeVersion.js](GrypeVersion.js).                                                                                                                                                     |               |
 | `config`            | Optional Grype configuration files (newline-separated). Setting this will disable auto-detection of configuration files (e.g. .grype.yaml) - only the specified files will be loaded..                                                                           |               |
+| `pr-comment`        | Post (or update) a comment with the scan results on the pull request that triggered the workflow. Requires `github-token` and a `pull_request` event. A single comment is reused across runs.                                                                    | `false`       |
+| `github-token`      | Token used to create or update the pull request comment when `pr-comment` is `true`. Typically set to `${{ github.token }}`. Requires the `pull-requests: write` permission.                                                                                     |               |
 
 ### Action Outputs
 
 | Output Name      | Description                                                                    | Type   |
-|------------------|--------------------------------------------------------------------------------|--------|
+| ---------------- | ------------------------------------------------------------------------------ | ------ |
 | `sarif`          | Path to the SARIF report file, if `output-format` is `sarif`                   | string |
 | `json`           | Path to the report file , if `output-format` is `json`                         | string |
 | `cyclonedx-xml`  | Path to the CycloneDX report file, if `output-format` is `cyclonedx`           | string |
@@ -218,7 +230,7 @@ A sub-action to [download Grype](download-grype/action.yml) and optionally cache
 Input parameters:
 
 | Parameter       | Description                                                                                                  | Default |
-|-----------------|--------------------------------------------------------------------------------------------------------------|---------|
+| --------------- | ------------------------------------------------------------------------------------------------------------ | ------- |
 | `grype-version` | An optional Grype version to download, defaults to the pinned version in [GrypeVersion.js](GrypeVersion.js). |         |
 | `cache-db`      | Cache the Grype DB in GitHub action cache and restore before checking for updates                            | `false` |
 

--- a/action.js
+++ b/action.js
@@ -136,6 +136,8 @@ async function run() {
     const configFile = core.getInput("config") || "";
     const cacheDb = core.getInput("cache-db") || "false";
     const outputFile = core.getInput("output-file") || "";
+    const prComment = core.getInput("pr-comment") || "false";
+    const githubToken = core.getInput("github-token") || "";
     const out = await runScan({
       source,
       failBuild,
@@ -148,6 +150,8 @@ async function run() {
       vex,
       configFile,
       cacheDb,
+      prComment,
+      githubToken,
     });
     Object.keys(out).map((key) => {
       core.setOutput(key, out[key]);
@@ -299,6 +303,8 @@ async function runScan({
   vex,
   configFile,
   cacheDb = "false",
+  prComment = "false",
+  githubToken = "",
 }) {
   const out = {};
 
@@ -341,6 +347,7 @@ async function runScan({
   addCpesIfNone = addCpesIfNone.toLowerCase() === "true";
   byCve = byCve.toLowerCase() === "true";
   cacheDb = cacheDb.toLowerCase() === "true" && cache.isFeatureAvailable();
+  prComment = prComment.toLowerCase() === "true";
 
   cmdArgs.push("-o", outputFormat);
 
@@ -450,7 +457,197 @@ async function runScan({
       core.setFailed("grype had a non-zero exit status when running");
     }
   }
+
+  // Optionally post the results as a pull request comment. This is best-effort:
+  // a failure to comment must never fail the scan itself.
+  if (prComment) {
+    try {
+      if (outputFormat !== "sarif") {
+        core.warning(
+          "pr-comment requires output-format 'sarif'; skipping comment",
+        );
+      } else {
+        const sarif = JSON.parse(fs.readFileSync(outputFile, "utf8"));
+        const body = buildPrCommentBody(parseSarifForComment(sarif));
+        await postPrComment({ token: githubToken, body });
+      }
+    } catch (e) {
+      core.warning(`unable to post pull request comment: ${e.message}`);
+    }
+  }
+
   return out;
 }
 
-export { run, runScan, installGrype, grypeVersion, updateDbWithCache };
+// Marker used to find and update this action's own PR comment across runs,
+// instead of posting a new comment each time.
+const PR_COMMENT_MARKER = "<!-- anchore/scan-action pr-comment -->";
+
+const SEVERITY_ORDER = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "negligible",
+  "unknown",
+];
+
+// Grype writes a "key: value" block into each SARIF rule's help.text; pull the
+// fields we display out of it.
+function parseGrypeHelpText(text) {
+  const fields = {};
+  for (const rawLine of (text || "").split("\n")) {
+    const line = rawLine.trim();
+    const vuln = line.match(/^Vulnerability\s+(.+)$/);
+    if (vuln) {
+      fields.Vulnerability = vuln[1].trim();
+      continue;
+    }
+    const kv = line.match(/^([A-Za-z][A-Za-z ]*):\s*(.*)$/);
+    if (kv) {
+      fields[kv[1].trim()] = kv[2].trim();
+    }
+  }
+  return fields;
+}
+
+// Turn a grype SARIF report into a list of vulnerabilities for the comment.
+function parseSarifForComment(sarif) {
+  const run = sarif && sarif.runs && sarif.runs[0];
+  if (!run || !Array.isArray(run.results)) {
+    return [];
+  }
+  const rules = {};
+  for (const rule of (run.tool && run.tool.driver && run.tool.driver.rules) ||
+    []) {
+    rules[rule.id] = rule;
+  }
+  return run.results.map((result) => {
+    const rule = rules[result.ruleId] || {};
+    const fields = parseGrypeHelpText(rule.help && rule.help.text);
+    return {
+      id: fields.Vulnerability || result.ruleId || "",
+      severity: (fields.Severity || "unknown").toLowerCase(),
+      package: fields.Package || "",
+      version: fields.Version || "",
+      fix: fields["Fix Version"] || "",
+      link: rule.helpUri || "",
+    };
+  });
+}
+
+// Build the markdown body of the PR comment from the parsed vulnerabilities.
+function buildPrCommentBody(vulnerabilities) {
+  if (vulnerabilities.length === 0) {
+    return `${PR_COMMENT_MARKER}\n## Grype scan results\n\nNo vulnerabilities found.`;
+  }
+
+  const counts = {};
+  for (const v of vulnerabilities) {
+    counts[v.severity] = (counts[v.severity] || 0) + 1;
+  }
+  const rank = (s) => {
+    const i = SEVERITY_ORDER.indexOf(s);
+    return i === -1 ? SEVERITY_ORDER.length : i;
+  };
+  const summary = SEVERITY_ORDER.filter((s) => counts[s])
+    .map((s) => `${counts[s]} ${s}`)
+    .join(", ");
+  const rows = [...vulnerabilities]
+    .sort((a, b) => rank(a.severity) - rank(b.severity))
+    .map((v) => {
+      const id = v.link ? `[${v.id}](${v.link})` : v.id;
+      return `| ${v.severity} | ${v.package} | ${v.version} | ${v.fix} | ${id} |`;
+    });
+
+  return [
+    PR_COMMENT_MARKER,
+    "## Grype scan results",
+    "",
+    `Found ${vulnerabilities.length} vulnerabilities (${summary}).`,
+    "",
+    "| Severity | Package | Version | Fix | Vulnerability |",
+    "| --- | --- | --- | --- | --- |",
+    ...rows,
+  ].join("\n");
+}
+
+// Minimal GitHub REST call using the built-in fetch, so the action does not
+// need an additional dependency.
+async function githubApiRequest(token, method, apiPath, body) {
+  const response = await fetch(`https://api.github.com${apiPath}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "anchore-scan-action",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API ${method} ${apiPath} failed: ${response.status}`,
+    );
+  }
+  return response.json();
+}
+
+// Create a new PR comment, or update the existing one this action posted.
+async function postPrComment({
+  token,
+  body,
+  env = process.env,
+  api = githubApiRequest,
+}) {
+  const eventName = env.GITHUB_EVENT_NAME;
+  if (eventName !== "pull_request" && eventName !== "pull_request_target") {
+    core.info(`pr-comment: not a pull request event (${eventName}), skipping`);
+    return;
+  }
+  if (!token) {
+    core.warning("pr-comment: no github-token provided, skipping");
+    return;
+  }
+
+  const event = JSON.parse(fs.readFileSync(env.GITHUB_EVENT_PATH, "utf8"));
+  const prNumber =
+    (event.pull_request && event.pull_request.number) || event.number;
+  const [owner, repo] = env.GITHUB_REPOSITORY.split("/");
+
+  const comments = await api(
+    token,
+    "GET",
+    `/repos/${owner}/${repo}/issues/${prNumber}/comments?per_page=100`,
+  );
+  const existing = (comments || []).find(
+    (c) => c.body && c.body.includes(PR_COMMENT_MARKER),
+  );
+
+  if (existing) {
+    await api(
+      token,
+      "PATCH",
+      `/repos/${owner}/${repo}/issues/comments/${existing.id}`,
+      { body },
+    );
+  } else {
+    await api(
+      token,
+      "POST",
+      `/repos/${owner}/${repo}/issues/${prNumber}/comments`,
+      { body },
+    );
+  }
+}
+
+export {
+  run,
+  runScan,
+  installGrype,
+  grypeVersion,
+  updateDbWithCache,
+  parseSarifForComment,
+  buildPrCommentBody,
+  postPrComment,
+};

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,13 @@ inputs:
   cache-db:
     description: "Cache the Grype DB in GitHub action cache and restore before checking for updates"
     required: false
+  pr-comment:
+    description: "Set to true to post (or update) a comment with the scan results on the pull request that triggered the workflow. Requires 'github-token' and a pull_request event. Default is false."
+    required: false
+    default: "false"
+  github-token:
+    description: "Token used to create or update the pull request comment when 'pr-comment' is true. Typically set to ${{ github.token }}. Requires 'pull-requests: write' permission."
+    required: false
 outputs:
   sarif:
     description: "Path to a SARIF report file for the scan"

--- a/dist/index.js
+++ b/dist/index.js
@@ -13329,7 +13329,7 @@ var require_fetch = __commonJS({
     function handleFetchDone(response) {
       finalizeAndReportTiming(response, "fetch");
     }
-    function fetch(input, init = void 0) {
+    function fetch2(input, init = void 0) {
       webidl.argumentLengthCheck(arguments, 1, "globalThis.fetch");
       let p = createDeferredPromise();
       let requestObject;
@@ -14286,7 +14286,7 @@ var require_fetch = __commonJS({
       }
     }
     module.exports = {
-      fetch,
+      fetch: fetch2,
       Fetch,
       fetching,
       finalizeAndReportTiming
@@ -18544,7 +18544,7 @@ var require_undici = __commonJS({
     module.exports.setGlobalDispatcher = setGlobalDispatcher;
     module.exports.getGlobalDispatcher = getGlobalDispatcher;
     var fetchImpl = require_fetch().fetch;
-    module.exports.fetch = async function fetch(init, options = void 0) {
+    module.exports.fetch = async function fetch2(init, options = void 0) {
       try {
         return await fetchImpl(init, options);
       } catch (err) {
@@ -65032,6 +65032,8 @@ async function run() {
     const configFile = getInput("config") || "";
     const cacheDb = getInput("cache-db") || "false";
     const outputFile = getInput("output-file") || "";
+    const prComment = getInput("pr-comment") || "false";
+    const githubToken = getInput("github-token") || "";
     const out = await runScan({
       source,
       failBuild,
@@ -65043,7 +65045,9 @@ async function run() {
       byCve,
       vex,
       configFile,
-      cacheDb
+      cacheDb,
+      prComment,
+      githubToken
     });
     Object.keys(out).map((key) => {
       setOutput(key, out[key]);
@@ -65163,7 +65167,9 @@ async function runScan({
   byCve,
   vex,
   configFile,
-  cacheDb = "false"
+  cacheDb = "false",
+  prComment = "false",
+  githubToken = ""
 }) {
   const out = {};
   const env = {
@@ -65200,6 +65206,7 @@ async function runScan({
   addCpesIfNone = addCpesIfNone.toLowerCase() === "true";
   byCve = byCve.toLowerCase() === "true";
   cacheDb = cacheDb.toLowerCase() === "true" && isFeatureAvailable();
+  prComment = prComment.toLowerCase() === "true";
   cmdArgs.push("-o", outputFormat);
   if (!outputFile) {
     outputFile = path12.join(
@@ -65281,7 +65288,160 @@ async function runScan({
       setFailed("grype had a non-zero exit status when running");
     }
   }
+  if (prComment) {
+    try {
+      if (outputFormat !== "sarif") {
+        warning(
+          "pr-comment requires output-format 'sarif'; skipping comment"
+        );
+      } else {
+        const sarif = JSON.parse(fs9.readFileSync(outputFile, "utf8"));
+        const body2 = buildPrCommentBody(parseSarifForComment(sarif));
+        await postPrComment({ token: githubToken, body: body2 });
+      }
+    } catch (e) {
+      warning(`unable to post pull request comment: ${e.message}`);
+    }
+  }
   return out;
+}
+var PR_COMMENT_MARKER = "<!-- anchore/scan-action pr-comment -->";
+var SEVERITY_ORDER = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "negligible",
+  "unknown"
+];
+function parseGrypeHelpText(text) {
+  const fields = {};
+  for (const rawLine of (text || "").split("\n")) {
+    const line = rawLine.trim();
+    const vuln = line.match(/^Vulnerability\s+(.+)$/);
+    if (vuln) {
+      fields.Vulnerability = vuln[1].trim();
+      continue;
+    }
+    const kv = line.match(/^([A-Za-z][A-Za-z ]*):\s*(.*)$/);
+    if (kv) {
+      fields[kv[1].trim()] = kv[2].trim();
+    }
+  }
+  return fields;
+}
+function parseSarifForComment(sarif) {
+  const run2 = sarif && sarif.runs && sarif.runs[0];
+  if (!run2 || !Array.isArray(run2.results)) {
+    return [];
+  }
+  const rules = {};
+  for (const rule of run2.tool && run2.tool.driver && run2.tool.driver.rules || []) {
+    rules[rule.id] = rule;
+  }
+  return run2.results.map((result) => {
+    const rule = rules[result.ruleId] || {};
+    const fields = parseGrypeHelpText(rule.help && rule.help.text);
+    return {
+      id: fields.Vulnerability || result.ruleId || "",
+      severity: (fields.Severity || "unknown").toLowerCase(),
+      package: fields.Package || "",
+      version: fields.Version || "",
+      fix: fields["Fix Version"] || "",
+      link: rule.helpUri || ""
+    };
+  });
+}
+function buildPrCommentBody(vulnerabilities) {
+  if (vulnerabilities.length === 0) {
+    return `${PR_COMMENT_MARKER}
+## Grype scan results
+
+No vulnerabilities found.`;
+  }
+  const counts = {};
+  for (const v of vulnerabilities) {
+    counts[v.severity] = (counts[v.severity] || 0) + 1;
+  }
+  const rank = (s) => {
+    const i = SEVERITY_ORDER.indexOf(s);
+    return i === -1 ? SEVERITY_ORDER.length : i;
+  };
+  const summary2 = SEVERITY_ORDER.filter((s) => counts[s]).map((s) => `${counts[s]} ${s}`).join(", ");
+  const rows = [...vulnerabilities].sort((a, b) => rank(a.severity) - rank(b.severity)).map((v) => {
+    const id = v.link ? `[${v.id}](${v.link})` : v.id;
+    return `| ${v.severity} | ${v.package} | ${v.version} | ${v.fix} | ${id} |`;
+  });
+  return [
+    PR_COMMENT_MARKER,
+    "## Grype scan results",
+    "",
+    `Found ${vulnerabilities.length} vulnerabilities (${summary2}).`,
+    "",
+    "| Severity | Package | Version | Fix | Vulnerability |",
+    "| --- | --- | --- | --- | --- |",
+    ...rows
+  ].join("\n");
+}
+async function githubApiRequest(token, method, apiPath, body2) {
+  const response = await fetch(`https://api.github.com${apiPath}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "anchore-scan-action"
+    },
+    body: body2 ? JSON.stringify(body2) : void 0
+  });
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API ${method} ${apiPath} failed: ${response.status}`
+    );
+  }
+  return response.json();
+}
+async function postPrComment({
+  token,
+  body: body2,
+  env = process4.env,
+  api = githubApiRequest
+}) {
+  const eventName = env.GITHUB_EVENT_NAME;
+  if (eventName !== "pull_request" && eventName !== "pull_request_target") {
+    info(`pr-comment: not a pull request event (${eventName}), skipping`);
+    return;
+  }
+  if (!token) {
+    warning("pr-comment: no github-token provided, skipping");
+    return;
+  }
+  const event = JSON.parse(fs9.readFileSync(env.GITHUB_EVENT_PATH, "utf8"));
+  const prNumber = event.pull_request && event.pull_request.number || event.number;
+  const [owner, repo] = env.GITHUB_REPOSITORY.split("/");
+  const comments = await api(
+    token,
+    "GET",
+    `/repos/${owner}/${repo}/issues/${prNumber}/comments?per_page=100`
+  );
+  const existing = (comments || []).find(
+    (c) => c.body && c.body.includes(PR_COMMENT_MARKER)
+  );
+  if (existing) {
+    await api(
+      token,
+      "PATCH",
+      `/repos/${owner}/${repo}/issues/comments/${existing.id}`,
+      { body: body2 }
+    );
+  } else {
+    await api(
+      token,
+      "POST",
+      `/repos/${owner}/${repo}/issues/${prNumber}/comments`,
+      { body: body2 }
+    );
+  }
 }
 
 // index.js

--- a/tests/pr_comment.test.js
+++ b/tests/pr_comment.test.js
@@ -1,0 +1,165 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  parseSarifForComment,
+  buildPrCommentBody,
+  postPrComment,
+} from "../action.js";
+
+// A small but realistic grype SARIF report (shape taken from real grype output).
+const sampleSarif = {
+  runs: [
+    {
+      tool: {
+        driver: {
+          rules: [
+            {
+              id: "CVE-2022-1111-openssl",
+              helpUri: "https://example.com/CVE-2022-1111",
+              help: {
+                text: "Vulnerability CVE-2022-1111\nSeverity: critical\nPackage: openssl\nVersion: 1.1.1\nFix Version: 1.1.1n",
+              },
+            },
+            {
+              id: "GHSA-aaaa-tar",
+              helpUri: "https://example.com/GHSA-aaaa",
+              help: {
+                text: "Vulnerability GHSA-aaaa\nSeverity: high\nPackage: tar\nVersion: 6.1.0\nFix Version: 6.1.1",
+              },
+            },
+          ],
+        },
+      },
+      results: [
+        { ruleId: "CVE-2022-1111-openssl", level: "error" },
+        { ruleId: "GHSA-aaaa-tar", level: "error" },
+      ],
+    },
+  ],
+};
+
+describe("parseSarifForComment", () => {
+  it("extracts fields from grype help text", () => {
+    const vulns = parseSarifForComment(sampleSarif);
+    assert.equal(vulns.length, 2);
+    assert.deepEqual(vulns[0], {
+      id: "CVE-2022-1111",
+      severity: "critical",
+      package: "openssl",
+      version: "1.1.1",
+      fix: "1.1.1n",
+      link: "https://example.com/CVE-2022-1111",
+    });
+  });
+
+  it("returns an empty list for an empty or malformed report", () => {
+    assert.deepEqual(parseSarifForComment({}), []);
+    assert.deepEqual(parseSarifForComment(null), []);
+  });
+});
+
+describe("buildPrCommentBody", () => {
+  it("includes the marker so comments can be updated in place", () => {
+    assert.match(
+      buildPrCommentBody([]),
+      /<!-- anchore\/scan-action pr-comment -->/,
+    );
+  });
+
+  it("reports a clean result when there are no vulnerabilities", () => {
+    assert.match(buildPrCommentBody([]), /No vulnerabilities found/);
+  });
+
+  it("summarizes counts and sorts most severe first", () => {
+    const body = buildPrCommentBody(parseSarifForComment(sampleSarif));
+    assert.match(body, /Found 2 vulnerabilities \(1 critical, 1 high\)/);
+    assert.ok(
+      body.indexOf("openssl") < body.indexOf("tar"),
+      "critical row should appear before high row",
+    );
+    assert.match(
+      body,
+      /\[CVE-2022-1111\]\(https:\/\/example\.com\/CVE-2022-1111\)/,
+    );
+  });
+});
+
+describe("postPrComment", () => {
+  function eventFile(payload) {
+    const p = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), "pr-comment-test-")),
+      "event.json",
+    );
+    fs.writeFileSync(p, JSON.stringify(payload));
+    return p;
+  }
+
+  const baseEnv = (eventPath) => ({
+    GITHUB_EVENT_NAME: "pull_request",
+    GITHUB_REPOSITORY: "octo/repo",
+    GITHUB_EVENT_PATH: eventPath,
+  });
+
+  it("skips when the event is not a pull request", async () => {
+    const calls = [];
+    await postPrComment({
+      token: "t",
+      body: "b",
+      env: { GITHUB_EVENT_NAME: "push" },
+      api: (...args) => calls.push(args),
+    });
+    assert.equal(calls.length, 0);
+  });
+
+  it("skips when no token is provided", async () => {
+    const calls = [];
+    await postPrComment({
+      token: "",
+      body: "b",
+      env: baseEnv(eventFile({ pull_request: { number: 5 } })),
+      api: (...args) => calls.push(args),
+    });
+    assert.equal(calls.length, 0);
+  });
+
+  it("creates a new comment when none exists", async () => {
+    const calls = [];
+    const api = (token, method, apiPath, body) => {
+      calls.push({ method, apiPath, body });
+      return method === "GET" ? [] : {};
+    };
+    await postPrComment({
+      token: "t",
+      body: "hello",
+      env: baseEnv(eventFile({ pull_request: { number: 5 } })),
+      api,
+    });
+    const post = calls.find((c) => c.method === "POST");
+    assert.ok(post, "expected a POST to create a comment");
+    assert.equal(post.apiPath, "/repos/octo/repo/issues/5/comments");
+    assert.equal(post.body.body, "hello");
+  });
+
+  it("updates the existing marked comment instead of creating a new one", async () => {
+    const calls = [];
+    const api = (token, method, apiPath, body) => {
+      calls.push({ method, apiPath, body });
+      return method === "GET"
+        ? [{ id: 42, body: "old <!-- anchore/scan-action pr-comment --> body" }]
+        : {};
+    };
+    await postPrComment({
+      token: "t",
+      body: "updated",
+      env: baseEnv(eventFile({ pull_request: { number: 7 } })),
+      api,
+    });
+    const patch = calls.find((c) => c.method === "PATCH");
+    assert.ok(patch, "expected a PATCH to update the comment");
+    assert.equal(patch.apiPath, "/repos/octo/repo/issues/comments/42");
+    assert.ok(!calls.find((c) => c.method === "POST"), "should not POST");
+  });
+});


### PR DESCRIPTION
Resolves #162.

Adds an option to post the Grype scan results as a comment on the pull request that triggered the workflow, as requested in #162. Per the maintainer guidance on that issue, this is built into the main action as an option rather than a separate sub-action.

## What it does

- New `pr-comment` input (default `false`) and `github-token` input.
- When `pr-comment: true` on a `pull_request` event, the action reads the SARIF report it already produces, and posts a summary comment: a per-severity count plus a table of findings (severity, package, version, fix, linked advisory).
- A hidden marker (`<!-- anchore/scan-action pr-comment -->`) is used to find and update a single comment across runs, instead of posting a new comment on every push.

## Notes

- **Best-effort:** any failure to comment is logged as a warning and never fails the scan.
- **No new runtime dependency:** comments are created/updated with the built-in `fetch` against the GitHub REST API.
- **Scan logic unchanged:** it reads the existing SARIF output file; it does not alter how `grype` is invoked. It requires `output-format: sarif` (the default) and warns + skips otherwise.
- Requires `pull-requests: write` permission on the token.

## Testing

- Added `tests/pr_comment.test.js` covering SARIF parsing, comment rendering (counts/sorting/links/empty), and the create-vs-update / skip paths (mocked API). `dist/` rebuilt.
