### PR TITLE
feat: support wildcards in the sbom input

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ The `path` key allows any valid path for the current project. The root of the pa
 
 ## Scanning an SBOM file
 
-Use the `sbom` key to scan an SBOM file:
+Use the `sbom` key to scan an SBOM file. The value may be a glob pattern (for
+example `sboms/*.spdx.json`), which must match exactly one file:
 
 ```yaml
 - name: Create SBOM
@@ -126,7 +127,7 @@ The inputs `image`, `path`, and `sbom` are mutually exclusive to specify the sou
 |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
 | `image`             | The image to scan                                                                                                                                                                                                                                                | N/A           |
 | `path`              | The file path to scan                                                                                                                                                                                                                                            | N/A           |
-| `sbom`              | The SBOM to scan                                                                                                                                                                                                                                                 | N/A           |
+| `sbom`              | The SBOM to scan; may be a glob pattern that matches exactly one file                                                                                                                                                                                            | N/A           |
 | `registry-username` | The registry username to use when authenticating to an external registry                                                                                                                                                                                         |               |
 | `registry-password` | The registry password to use when authenticating to an external registry                                                                                                                                                                                         |               |
 | `fail-build`        | Fail the build if a vulnerability is found with a higher severity. That severity defaults to `medium` and can be set with `severity-cutoff`.                                                                                                                     | `true`        |

--- a/action.js
+++ b/action.js
@@ -109,7 +109,13 @@ function sourceInput() {
   }
 
   if (sbom) {
-    return "sbom:" + sbom;
+    const matches = fs.globSync(sbom);
+    if (matches.length !== 1) {
+      throw new Error(
+        `The "sbom" input "${sbom}" matched ${matches.length} files, but exactly 1 is required`,
+      );
+    }
+    return "sbom:" + matches[0];
   }
 
   if (!path) {

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'The path to scan. This option is mutually exclusive with "image" and "sbom".'
     required: false
   sbom:
-    description: 'The SBOM file to scan. This option is mutually exclusive with "path" and "image".'
+    description: 'The SBOM file to scan. May be a glob pattern, which must match exactly one file. This option is mutually exclusive with "path" and "image".'
     required: false
   fail-build:
     description: "Set to false to avoid failing based on severity-cutoff. Default is to fail when severity-cutoff is reached (or surpassed)"

--- a/dist/index.js
+++ b/dist/index.js
@@ -65011,7 +65011,13 @@ function sourceInput() {
     return image;
   }
   if (sbom) {
-    return "sbom:" + sbom;
+    const matches = fs9.globSync(sbom);
+    if (matches.length !== 1) {
+      throw new Error(
+        `The "sbom" input "${sbom}" matched ${matches.length} files, but exactly 1 is required`
+      );
+    }
+    return "sbom:" + matches[0];
   }
   if (!path13) {
     return "dir:.";

--- a/tests/action.test.js
+++ b/tests/action.test.js
@@ -194,6 +194,30 @@ describe("Github action", () => {
     assert.match(failure, /Failed minimum severity level./);
   });
 
+  it("runs with sbom glob matching one file", async () => {
+    const { failure } = await runCapturing({
+      sbom: "tests/fixtures/test_sbom.*.json",
+    });
+
+    assert.match(failure, /Failed minimum severity level./);
+  });
+
+  it("errors when sbom glob matches no files", async () => {
+    const { failure } = await runCapturing({
+      sbom: "tests/fixtures/does-not-exist-*.json",
+    });
+
+    assert.match(failure, /matched 0 files, but exactly 1 is required/);
+  });
+
+  it("errors when sbom glob matches multiple files", async () => {
+    const { failure } = await runCapturing({
+      sbom: "tests/fixtures/sbom-glob/*.cdx.json",
+    });
+
+    assert.match(failure, /matched 2 files, but exactly 1 is required/);
+  });
+
   it("outputs errors", async () => {
     const { stdout } = await runCapturing({
       sbom: "tests/fixtures/test_sbom.spdx.json",

--- a/tests/fixtures/sbom-glob/first.cdx.json
+++ b/tests/fixtures/sbom-glob/first.cdx.json
@@ -1,0 +1,1 @@
+{"bomFormat":"CycloneDX","specVersion":"1.5","version":1,"metadata":{}}

--- a/tests/fixtures/sbom-glob/second.cdx.json
+++ b/tests/fixtures/sbom-glob/second.cdx.json
@@ -1,0 +1,1 @@
+{"bomFormat":"CycloneDX","specVersion":"1.5","version":1,"metadata":{}}


### PR DESCRIPTION
Adds glob pattern support to the `sbom` input. Previously the value was passed
to grype verbatim, so a pattern like `*/*.cdx.json` failed with `unable to open
file`. The input is now expanded with `fs.globSync`; per the maintainer's note
on the issue, it must resolve to exactly one file, otherwise the action fails
with a clear error.

Uses the Node built-in `fs.globSync` (runtime is `node24`), so no new dependency
is added.

Validation:
- `npm test` (lint + build + tests): 33 tests, 33 pass, 0 fail
- New tests cover glob matching exactly one file (runs), zero files (errors), and multiple files (errors)
- `dist/index.js` rebuilt via `npm run build`

Closes #673
